### PR TITLE
fix: audit Tier A+B (doc accuracy + hardening)

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -166,7 +166,10 @@ jobs:
 
           link_re = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
           all_ok = True
-          for md in Path("plugins").glob("**/*.md"):
+          md_files = list(Path("plugins").glob("**/*.md")) + [
+              p for p in Path(".").glob("*.md") if p.is_file()
+          ]
+          for md in md_files:
               text = md.read_text()
               for match in link_re.finditer(text):
                   target = match.group(1).split("#")[0]

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -157,6 +157,23 @@ jobs:
           done < <(find plugins -name '*.sh' -o -name 'pp' -o -name 'install.sh')
           exit $fail
 
+      - name: ShellCheck
+        run: |
+          # ubuntu-latest ships with shellcheck preinstalled.
+          # We run at --severity=warning to catch real bugs (unquoted vars,
+          # missing cd-or-exit, redundant case patterns) without being noisy
+          # about style. Bump to info/style only after the codebase is clean.
+          fail=0
+          while IFS= read -r script; do
+              if shellcheck --severity=warning "$script"; then
+                  echo "OK    $script"
+              else
+                  echo "FAIL  $script" >&2
+                  fail=1
+              fi
+          done < <(find plugins -name '*.sh' -o -name 'pp' -o -name 'install.sh' -o -name 'pre-commit')
+          exit $fail
+
       - name: Check internal markdown links
         run: |
           python3 <<'PY_EOF'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,7 +198,7 @@ Six reference-layer gaps surfaced by the v2.2.0 recipes pass, now closed:
 
 ### Initial public release
 
-Three plugins in the `nq-claude-power-pages-plugins` marketplace at v1.0.0 each, sanitized and verified leak-free.
+Three plugins in the `nq-claude-plugins` marketplace at v1.0.0 each, sanitized and verified leak-free. (The marketplace was later renamed to `nq-claude-power-pages-plugins` at v2.5.0.)
 
 #### pp-liquid (v1.0.0)
 Knowledge skill for Power Pages classic Liquid templating. 8 reference files covering FetchXML count+paginate+filter, Web API in custom JS with the safeAjax / `__RequestVerificationToken` pattern, entity tags (entitylist, entityform, webform), DotLiquid quirks vs Shopify Liquid, hybrid render-then-mutate pages, and a troubleshooting matrix mapping common errors to causes and fixes.
@@ -219,8 +219,8 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 [2.6.1]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.6.1
 [2.6.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.6.0
 [2.5.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.5.0
-[2.3.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.3.0
 [2.4.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.4.0
+[2.3.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.3.0
 [2.2.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.2.0
 [2.1.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.1.0
 [2.0.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.0.0

--- a/plugins/pp-sync/README.md
+++ b/plugins/pp-sync/README.md
@@ -23,11 +23,16 @@ A **rigid action skill** — has a checklist of steps that must run in order. De
 |---|---|
 | **down** | Download portal from Dataverse to local |
 | **up** | Upload local changes to Dataverse |
+| **diff** | Preview what `up` would push (no upload) |
 | **doctor** | Health check (auth, tooling, structure, noise) |
-| **commit** | Interactive selective commit |
+| **generate-page** | Scaffold a new hybrid-pattern page (base + en-US) |
+| **sync-pages** | Bulk-copy between base and localized webpage variants |
+| **journal** | Automated work tracking & Project Board integration |
 | **solution-down** | Export Dataverse solution + unpack |
 | **solution-up** | Pack + import Dataverse solution |
-| **portal-restart** | Recover from hung portal cache |
+| **audit** | Run permissions audit (delegates to `pp-permissions-audit`) |
+
+For interactive commits, use `git` directly or copy `templates/commit.sh` into your project. Portal cache recovery is an Admin Center action — see `references/safety-checks.md`.
 
 ## Reference files
 

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -37,10 +37,10 @@ PP_ACTIVE_FILE="$PP_CONFIG_DIR/active"
 # ===========================================================================
 
 if [ -t 1 ]; then
-    BOLD=$'\033[1m'; DIM=$'\033[2m'; RED=$'\033[31m'; GRN=$'\033[32m'
+    BOLD=$'\033[1m'; RED=$'\033[31m'; GRN=$'\033[32m'
     YLW=$'\033[33m'; BLU=$'\033[34m'; RST=$'\033[0m'
 else
-    BOLD=""; DIM=""; RED=""; GRN=""; YLW=""; BLU=""; RST=""
+    BOLD=""; RED=""; GRN=""; YLW=""; BLU=""; RST=""
 fi
 
 info()  { printf '%s→%s %s\n' "$BLU" "$RST" "$*"; }
@@ -48,6 +48,18 @@ ok()    { printf '%s✓%s %s\n' "$GRN" "$RST" "$*"; }
 warn()  { printf '%s⚠%s %s\n' "$YLW" "$RST" "$*" >&2; }
 err()   { printf '%s✗%s %s\n' "$RED" "$RST" "$*" >&2; }
 die()   { err "$@"; exit 1; }
+
+# Reject identifiers that contain shell metacharacters, whitespace, or
+# anything else that would be unsafe to interpolate into bash heredocs,
+# regex patterns, or filename components. Used at every registration site
+# so that values written into ~/.config/nq-pp-sync/projects/*.conf cannot
+# be crafted to inject commands when the conf is later sourced.
+validate_identifier() {
+    local field="$1" value="$2" pattern="${3:-^[A-Za-z0-9_.-]+\$}"
+    if [[ ! "$value" =~ $pattern ]]; then
+        die "$field must match $pattern: got '$value'"
+    fi
+}
 
 # ===========================================================================
 # Project registry helpers
@@ -168,7 +180,7 @@ cd_repo_root() {
     # If this is a git repo, snap to its top
     local top
     top=$(git rev-parse --show-toplevel 2>/dev/null || true)
-    [ -n "$top" ] && cd "$top"
+    [ -n "$top" ] && cd "$top" || return
 }
 
 confirm_pac_profile() {
@@ -255,6 +267,7 @@ cmd_setup() {
         local name
         read -r -p "Project name [$default_name]: " name
         name="${name:-$default_name}"
+        validate_identifier "Project name" "$name" '^[A-Za-z0-9_-]+$'
         if [ -f "$PP_PROJECTS_DIR/$name.conf" ]; then
             warn "$name already registered — skipping"
             continue
@@ -265,6 +278,9 @@ cmd_setup() {
         local alias_input
         read -r -p "Shorthand alias [$suggested_alias, or 'none']: " alias_input
         alias_input="${alias_input:-$suggested_alias}"
+        if [ "$alias_input" != "none" ]; then
+            validate_identifier "Alias" "$alias_input" '^[A-Za-z0-9_-]+$'
+        fi
 
         # Auto-fill what we can
         local repo site_rel pac_profile env_url
@@ -287,6 +303,7 @@ cmd_setup() {
         echo
         read -r -p "PAC profile name (exact, from list): " pac_profile
         [ -z "$pac_profile" ] && { warn "Skipping (no profile given)"; continue; }
+        validate_identifier "PAC profile" "$pac_profile" '^[A-Za-z0-9_.-]+$'
 
         # Get env URL for that profile
         if pac auth select --name "$pac_profile" >/dev/null 2>&1; then
@@ -553,7 +570,7 @@ cmd_up() {
     actual_env=$(confirm_pac_profile "$PROFILE")
 
     case "$actual_env" in
-        *prod*|*production*)
+        *prod*)
             warn "${BOLD}PRODUCTION ENVIRONMENT${RST}"
             local ans
             read -r -p "Type the project name '$name' to confirm prod upload: " ans
@@ -868,8 +885,14 @@ cmd_solution_down() {
         rm -rf "$unpack_dir.bak"
         mv "$unpack_dir" "$unpack_dir.bak"
     fi
-    mv "$unpack_dir.new" "$unpack_dir"
-    rm -rf "$unpack_dir.bak"
+    # Chain rather than separate statements: if the second mv fails, keep
+    # the .bak copy so the user has not lost their previous unpacked schema.
+    if mv "$unpack_dir.new" "$unpack_dir"; then
+        rm -rf "$unpack_dir.bak"
+    else
+        warn "mv to $unpack_dir failed; previous copy preserved at $unpack_dir.bak"
+        die "Solution unpack swap failed"
+    fi
     rm -f "$zipfile"
 
     local entity_count
@@ -919,7 +942,7 @@ cmd_solution_up() {
     confirm_action "Confirm import '$solution' to $actual_env ?"
 
     case "$actual_env" in
-        *prod*|*production*)
+        *prod*)
             warn "${BOLD}PRODUCTION ENVIRONMENT${RST}"
             local ans
             read -r -p "Type the solution name '$solution' to confirm: " ans
@@ -1269,12 +1292,14 @@ cmd_project_add() {
     local name="${1:-}"
     [ -z "$name" ] && { read -r -p "Project name: " name; }
     [ -z "$name" ] && die "Project name required"
+    validate_identifier "Project name" "$name" '^[A-Za-z0-9_-]+$'
     [ -f "$PP_PROJECTS_DIR/$name.conf" ] && die "$name already exists. Use 'pp project edit' or remove first."
 
     local repo site_dir profile website_id env_url solutions branch board_url board_system ai_attr
     read -r -p "Repo path:       " repo
     read -r -p "Site folder (relative): " site_dir
     read -r -p "PAC profile:     " profile
+    [ -n "$profile" ] && validate_identifier "PAC profile" "$profile" '^[A-Za-z0-9_.-]+$'
     read -r -p "Website ID:      " website_id
     read -r -p "Env URL:         " env_url
     read -r -p "Solutions (comma-separated): " solutions
@@ -1312,6 +1337,7 @@ EOF
     local alias_input
     read -r -p "Add an alias? (blank = none): " alias_input
     if [ -n "$alias_input" ]; then
+        validate_identifier "Alias" "$alias_input" '^[A-Za-z0-9_-]+$'
         echo "${alias_input}=${name}" >> "$PP_ALIASES_FILE"
         ok "Alias: pp <op> $alias_input"
     fi
@@ -1344,7 +1370,10 @@ cmd_alias_add() {
     ensure_config_dirs
     local alias_name="${1:-}"
     local target="${2:-}"
-    [ -z "$alias_name" ] || [ -z "$target" ] && die "Usage: pp alias add <alias> <project>"
+    if [ -z "$alias_name" ] || [ -z "$target" ]; then
+        die "Usage: pp alias add <alias> <project>"
+    fi
+    validate_identifier "Alias" "$alias_name" '^[A-Za-z0-9_-]+$'
     local resolved
     resolved=$(resolve_project "$target") || die "Unknown target: $target"
     if grep -qE "^${alias_name}=" "$PP_ALIASES_FILE" 2>/dev/null; then

--- a/plugins/pp-sync/completion/pp.bash
+++ b/plugins/pp-sync/completion/pp.bash
@@ -8,6 +8,17 @@
 #
 # After install, restart the shell or:  source ~/.bashrc
 
+# Populate COMPREPLY safely: each compgen match goes in as a single element,
+# without word-splitting on whitespace or glob-expanding shell metacharacters
+# that may appear in registered project names. Works on bash 3.2+ (no mapfile).
+_pp_set_comp_reply() {
+    local wordlist="$1" current="$2" line
+    COMPREPLY=()
+    while IFS= read -r line; do
+        [ -n "$line" ] && COMPREPLY+=( "$line" )
+    done < <(compgen -W "$wordlist" -- "$current")
+}
+
 _pp_completion() {
     local cur prev words cword
     _init_completion -n : 2>/dev/null || {
@@ -36,7 +47,7 @@ _pp_completion() {
 
     # Subcommand at position 1
     if [[ $cword -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+        _pp_set_comp_reply "$subcommands" "$cur"
         return 0
     fi
 
@@ -45,21 +56,21 @@ _pp_completion() {
         down|d|up|u|doctor|switch|use|show|sync-pages|audit|solution-down|sol-down|solution-up|sol-up)
             # First arg is a project name
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=( $(compgen -W "$(_pp_projects)" -- "$cur") )
+                _pp_set_comp_reply "$(_pp_projects)" "$cur"
                 return 0
             fi
             ;;
         project)
             # Subcommand: add | edit | remove | list
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=( $(compgen -W "add edit remove rm list ls" -- "$cur") )
+                _pp_set_comp_reply "add edit remove rm list ls" "$cur"
                 return 0
             fi
             # Project arg for edit/remove
             if [[ $cword -eq 3 ]]; then
                 case "${COMP_WORDS[2]}" in
                     edit|remove|rm)
-                        COMPREPLY=( $(compgen -W "$(_pp_projects)" -- "$cur") )
+                        _pp_set_comp_reply "$(_pp_projects)" "$cur"
                         return 0
                         ;;
                 esac
@@ -68,12 +79,12 @@ _pp_completion() {
         alias)
             # Subcommand: add | list
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=( $(compgen -W "add list ls" -- "$cur") )
+                _pp_set_comp_reply "add list ls" "$cur"
                 return 0
             fi
             # `alias add <new-alias> <project>` — project completion at position 4
             if [[ $cword -eq 4 && "${COMP_WORDS[2]}" = "add" ]]; then
-                COMPREPLY=( $(compgen -W "$(_pp_projects)" -- "$cur") )
+                _pp_set_comp_reply "$(_pp_projects)" "$cur"
                 return 0
             fi
             ;;
@@ -82,19 +93,19 @@ _pp_completion() {
     # Position 3+: flags for some subcommands
     case "${COMP_WORDS[1]}" in
         down|d)
-            COMPREPLY=( $(compgen -W "--no-clean" -- "$cur") )
+            _pp_set_comp_reply "--no-clean" "$cur"
             ;;
         up|u)
-            COMPREPLY=( $(compgen -W "--validate-only --force-bulk --bulk-threshold=" -- "$cur") )
+            _pp_set_comp_reply "--validate-only --force-bulk --bulk-threshold=" "$cur"
             ;;
         sync-pages)
-            COMPREPLY=( $(compgen -W "base-to-localized localized-to-base" -- "$cur") )
+            _pp_set_comp_reply "base-to-localized localized-to-base" "$cur"
             ;;
         audit)
-            COMPREPLY=( $(compgen -W "--severity --exit-code --json -o --output" -- "$cur") )
+            _pp_set_comp_reply "--severity --exit-code --json -o --output" "$cur"
             # Severity values
             if [[ "$prev" = "--severity" ]]; then
-                COMPREPLY=( $(compgen -W "ERROR WARN INFO" -- "$cur") )
+                _pp_set_comp_reply "ERROR WARN INFO" "$cur"
             fi
             ;;
     esac

--- a/plugins/pp-sync/skills/pp-sync/SKILL.md
+++ b/plugins/pp-sync/skills/pp-sync/SKILL.md
@@ -42,17 +42,20 @@ User says any of:
 
 ## Operations supported
 
-| Operation | What it does | Wrapper if exists | Bare command fallback |
+| Operation | `pp` subcommand | Wrapper script alternative | Bare command fallback |
 |---|---|---|---|
-| **down** | Download portal from Dataverse to local | `*-down.sh` / `*-paportal-down.sh` / `sync-down-dev.sh` | `pac paportal download --path . --webSiteId <id> --modelVersion <n>` |
-| **up** | Upload local changes to Dataverse | `*-up.sh` / `*-paportal-up.sh` / `sync-up-dev.sh` | `pac paportal upload --path . --modelVersion <n>` |
-| **doctor** | Health check (auth, tooling, structure, noise) | `*-doctor.sh` / `contosodoctor.sh` | manual checks (see `references/safety-checks.md`) |
-| **generate-page** | **Scaffold a new hybrid-pattern page (base + en-US)** | (internal template) | manual mkdir + copy |
-| **journal** | **Automated work tracking & Project Board integration** | (internal logic) | `gh` / `glab` / `git commit` |
-| **commit** | Interactive selective commit | `*-commit.sh` | `git status` + `git add -p` + `git commit` |
-| **solution-down** | Export Dataverse solution + unpack | `*-solution-down.sh` | `pac solution export` then `pac solution unpack` |
-| **solution-up** | Import Dataverse solution | `*-solution-up.sh` | `pac solution pack` then `pac solution import` |
-| **portal-restart** | Recover from hung portal cache | (none — admin center action) | Open Power Platform Admin Center → Restart |
+| **down** | `pp down` | `*-down.sh` / `*-paportal-down.sh` / `sync-down-dev.sh` | `pac paportal download --path . --webSiteId <id> --modelVersion <n>` |
+| **up** | `pp up` | `*-up.sh` / `*-paportal-up.sh` / `sync-up-dev.sh` | `pac paportal upload --path . --modelVersion <n>` |
+| **diff** | `pp diff` | (none) | `git diff` over the site folder + manual filtering |
+| **doctor** | `pp doctor` | `*-doctor.sh` / `contosodoctor.sh` | manual checks (see `references/safety-checks.md`) |
+| **generate-page** | `pp generate-page` | (internal template) | manual mkdir + copy |
+| **sync-pages** | `pp sync-pages` | (internal logic) | manual copy between base and `content-pages/<lang>/` variants |
+| **journal** | `pp journal` | (internal logic) | `gh` / `glab` / `git commit` |
+| **solution-down** | `pp solution-down` | `*-solution-down.sh` | `pac solution export` then `pac solution unpack` |
+| **solution-up** | `pp solution-up` | `*-solution-up.sh` | `pac solution pack` then `pac solution import` |
+| **audit** | `pp audit` | (internal logic) | `python3 audit.py <site-dir>` |
+| **commit** | _no `pp` subcommand_ | `templates/commit.sh` | `git status` + `git add -p` + `git commit` |
+| **portal-restart** | _no `pp` subcommand_ | (none — admin center action) | Open Power Platform Admin Center → Restart |
 
 ## Mandatory checklist for ANY sync operation
 

--- a/plugins/pp-sync/skills/pp-sync/references/cli-reference.md
+++ b/plugins/pp-sync/skills/pp-sync/references/cli-reference.md
@@ -56,6 +56,7 @@ All sync commands take a project as the first argument. The project arg can be t
 | `pp diff <project> [--diff] [--names-only] [--bulk-threshold=N]` | Preview what `pp up` would push — categorized changed-file list, no upload |
 | `pp doctor <project>` | Health check — tooling, auth, structure, content counts |
 | `pp generate-page <project> <Name>` | Scaffold a new hybrid-pattern page (base + en-US) |
+| `pp sync-pages <project> [direction]` | Bulk-copy between base `<Page>.webpage.copy.html` and localized `content-pages/<lang>/` variants. Direction is `base-to-localized` or `localized-to-base`; omit for interactive prompt |
 | `pp journal <project> {init|open|note|close} <args>` | Automated work tracking & Project Board integration |
 | `pp solution-down <project> [solution]` | Export Dataverse solution + unpack |
 | `pp solution-up <project> [solution]` | Pack + import Dataverse solution (DESTRUCTIVE) |

--- a/plugins/pp-sync/templates/commit.sh
+++ b/plugins/pp-sync/templates/commit.sh
@@ -57,7 +57,7 @@ git commit -m "$msg"
 
 # 6. Optional push
 read -r -p "Push to remote? [y/N] " push
-if [ "${push,,}" = "y" ]; then
+if [ "$(printf '%s' "$push" | tr '[:upper:]' '[:lower:]')" = "y" ]; then
   BRANCH=$(git branch --show-current)
   git push -u origin "$BRANCH"
 fi

--- a/plugins/pp-sync/templates/doctor.sh
+++ b/plugins/pp-sync/templates/doctor.sh
@@ -14,7 +14,7 @@ PROFILE="${PROFILE:-PUT_PAC_PROFILE_HERE}"
 # =====================================
 
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 OK="✓"
 WARN="⚠"

--- a/plugins/pp-sync/templates/down.sh
+++ b/plugins/pp-sync/templates/down.sh
@@ -44,13 +44,13 @@ if [ -z "$ENV_URL" ]; then
 fi
 echo "→ Active env: $ENV_URL"
 read -r -p "Continue download into $SITE_DIR ? [y/N] " ans
-[ "${ans,,}" = "y" ] || { echo "Aborted."; exit 0; }
+[ "$(printf '%s' "$ans" | tr '[:upper:]' '[:lower:]')" = "y" ] || { echo "Aborted."; exit 0; }
 
 # 3. Working tree check — warn if uncommitted changes exist
 if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
   echo "⚠ Uncommitted changes in working tree. Download may overwrite local edits."
   read -r -p "Continue anyway? [y/N] " ans
-  [ "${ans,,}" = "y" ] || { echo "Aborted."; exit 0; }
+  [ "$(printf '%s' "$ans" | tr '[:upper:]' '[:lower:]')" = "y" ] || { echo "Aborted."; exit 0; }
 fi
 
 # 4. Download

--- a/plugins/pp-sync/templates/solution-down.sh
+++ b/plugins/pp-sync/templates/solution-down.sh
@@ -29,7 +29,7 @@ echo "→ Active env: $ENV_URL"
 
 # 2. Confirm before exporting (export takes 60-120s; user should know)
 read -r -p "Export solution '$SOLUTION' from $ENV_URL ? [y/N] " ans
-[ "${ans,,}" = "y" ] || { echo "Aborted."; exit 0; }
+[ "$(printf '%s' "$ans" | tr '[:upper:]' '[:lower:]')" = "y" ] || { echo "Aborted."; exit 0; }
 
 # 3. Export — use a long timeout via curl-style; pac handles internally
 echo "→ Exporting solution… (may take 60-120s)"
@@ -57,8 +57,12 @@ if [ -d "$UNPACK_DIR" ]; then
   rm -rf "$UNPACK_DIR.bak"
   mv "$UNPACK_DIR" "$UNPACK_DIR.bak"
 fi
-mv "$UNPACK_DIR.new" "$UNPACK_DIR"
-rm -rf "$UNPACK_DIR.bak"
+if mv "$UNPACK_DIR.new" "$UNPACK_DIR"; then
+  rm -rf "$UNPACK_DIR.bak"
+else
+  echo "ERROR: mv to $UNPACK_DIR failed; previous copy preserved at $UNPACK_DIR.bak" >&2
+  exit 1
+fi
 
 # 6. Optional: remove the .zip (it's reproducible from unpacked)
 rm -f "$ZIPFILE"

--- a/plugins/pp-sync/templates/solution-up.sh
+++ b/plugins/pp-sync/templates/solution-up.sh
@@ -33,10 +33,10 @@ ENV_URL=$(pac org who 2>&1 | awk -F': ' '/Environment Url/{print $2; exit}')
 echo "→ Active env: $ENV_URL"
 echo "⚠ Solution import is DESTRUCTIVE — it overwrites schema in the target env."
 read -r -p "Confirm import '$SOLUTION' to $ENV_URL ? [y/N] " ans
-[ "${ans,,}" = "y" ] || { echo "Aborted."; exit 0; }
+[ "$(printf '%s' "$ans" | tr '[:upper:]' '[:lower:]')" = "y" ] || { echo "Aborted."; exit 0; }
 
 case "$ENV_URL" in
-  *prod*|*production*)
+  *prod*)
     echo "⚠⚠⚠  PRODUCTION ENVIRONMENT  ⚠⚠⚠"
     read -r -p "Type the solution name '$SOLUTION' to confirm prod import: " confirm
     [ "$confirm" = "$SOLUTION" ] || { echo "Aborted."; exit 0; }

--- a/plugins/pp-sync/templates/up.sh
+++ b/plugins/pp-sync/templates/up.sh
@@ -77,7 +77,7 @@ Options:
 
 EOF
   read -r -p "Continue with bulk upload? [y/N] " ans
-  [ "${ans,,}" = "y" ] || { echo "Aborted."; exit 0; }
+  [ "$(printf '%s' "$ans" | tr '[:upper:]' '[:lower:]')" = "y" ] || { echo "Aborted."; exit 0; }
 fi
 
 # 4. Upload (or validate)

--- a/plugins/pp-sync/templates/up.sh
+++ b/plugins/pp-sync/templates/up.sh
@@ -48,7 +48,7 @@ echo "→ Active env: $ENV_URL"
 
 # Extra warning for prod env URLs
 case "$ENV_URL" in
-  *prod*|*production*)
+  *prod*)
     echo "⚠⚠⚠  PRODUCTION ENVIRONMENT  ⚠⚠⚠"
     read -r -p "Are you SURE you want to upload to prod? Type 'yes' to continue: " ans
     [ "$ans" = "yes" ] || { echo "Aborted."; exit 0; }


### PR DESCRIPTION
Closes #2 (Tier A) and #3 (Tier B). Part of #1.

Two-commit branch addressing 14 of 18 findings from the 2026-04-29 internal audit. Tier C (architectural refactor of conf-file sourcing + \`set -e\` migration) follows in a separate PR.

## Tier A — documentation accuracy (e23e22c)

| Fix | What changed |
|---|---|
| Drop fictitious commands | \`pp commit\` is rejected at \`bin/pp:1444\`; \`pp portal-restart\` was never implemented. Removed from pp-sync README + SKILL operations tables. |
| Add real command | \`pp sync-pages\` (real, at \`bin/pp:974\`) was missing from \`cli-reference.md\`. |
| Bash 3.2 compat | \`\${var,,}\` in \`commit.sh\`, \`down.sh\`, \`up.sh\` replaced with portable \`printf \| tr\` form. macOS bash 3.2 default. |
| Link-checker coverage | CI's markdown link checker glob extended to root README/CHANGELOG/CONTRIBUTING (was \`plugins/**/*.md\` only). |
| CHANGELOG | v1.0.0 retroactive marketplace name corrected to \`nq-claude-plugins\` (rename to \`nq-claude-power-pages-plugins\` was at v2.5.0); link-ref ordering. |

## Tier B — hardening (931fa33)

**Input validation** — new \`validate_identifier()\` helper in \`bin/pp\` rejects shell metacharacters at every registration site (project name, alias, PAC profile). Tested against 8 attack vectors locally:
- Accepts: alphanumeric, underscores, dashes, dots (PAC profile only)
- Rejects: \`;\`, \`\$\`, \`\"\`, space, backtick, empty

**Atomic mv-chain** — \`cmd_solution_down\` and \`templates/solution-down.sh\` previously did \`mv X X.bak; mv X.new X; rm -rf X.bak\`. If the second mv failed, rm wiped the only good copy. Now chained — rm only runs after successful mv.

**ShellCheck in CI** — added at \`--severity=warning\`. All 11 scripts pass clean. Cleared 7 pre-existing warnings (unused var, missing cd-or-exit, redundant \`*prod*|*production*\` patterns, ambiguous boolean in \`cmd_alias_add\`).

**Completion safety** — replaced 8 unquoted \`COMPREPLY=( \$(compgen ...) )\` in \`pp.bash\` with a safe helper. Bash 3.2 compatible (no \`mapfile\`).

**Two more bash 3.2 incompatibilities** — \`\${ans,,}\` in \`solution-up.sh\` and \`solution-down.sh\` (missed in Tier A).

## Local CI parity

All 7 workflow steps pass:
- Version sync ✓
- Plugin manifests ✓
- SKILL.md frontmatter ✓
- audit.py compile + 6 unit tests ✓
- Bash syntax ✓
- ShellCheck (new) ✓
- Markdown link checker (extended) ✓

## What's deferred to Tier C

- **#1 finding**: \`source \"\$conf\"\` in \`load_project()\` — Tier B's input validation closes the most reachable paths (registration prompts) but path/URL fields (\`REPO\`, \`SITE_DIR\`, \`ENV_URL\`, \`BOARD_URL\`) and pre-existing or hand-edited conf files remain unprotected. Tier C replaces \`source\` with a strict key=value parser.
- **#2 (rest)**: full \`set -euo pipefail\` migration in \`bin/pp\`.

## Test plan

- [x] CI green
- [x] All shellcheck warnings cleared on touched scripts
- [x] \`validate_identifier\` unit-tested locally against 8 valid/invalid cases
- [ ] Manual smoke test: \`pp setup\` rejects a project name with a semicolon
- [ ] Manual smoke test: simulated mv failure preserves \`.bak\` directory