### PR TITLE
v2.7.3: 7 follow-ups from third independent review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.7.3] — 2026-04-29
+
+Third independent review pass. Each prior pass found 5+ real bugs; this pass surfaced 7 more across untested code paths. None are CVE-class — the architectural conf-source sink stayed closed — but each is a real bug that would bite users in normal operation.
+
+### Fixed (pp-sync v2.0.2)
+
+- **`pp generate-page` now validates the page name** against `^[A-Za-z0-9 _.-]+$` and explicitly rejects `..`, `/`, and `\`. Previously the page name flowed unchecked into filename paths and YAML/HTML heredocs — an input like `../../etc/foo` would have written outside the site directory; one with embedded quotes could have produced malformed YAML.
+- **`pp doctor` no longer aborts under bash strict mode when run outside a git tree.** The `git status --porcelain | wc -l | tr -d ' '` pipeline tripped pipefail because `git` exits 128 in non-git directories. Same fix applied to similar counters in `cmd_up`, `cmd_diff`, and the doctor site-content counts. Each now ends with `|| echo 0`.
+- **`pp journal note|close` finds the URL from `Issue:` lines specifically**, not "the last URL of any kind in JOURNAL.md". Previously a note containing an inline cross-repo reference (`see also https://other-org/other-repo/issues/42`) became the validator's target, locking the user out of further `note`/`close` operations until they hand-edited the journal. Now the extraction matches `^Issue: https://...` — only the URLs `pp journal open` actually wrote.
+- **`pp journal open` (github branch) filters `gh issue create` output** through `grep -oE 'https://github\.com/.../issues/[0-9]+'` before persisting to JOURNAL.md, mirroring the gitlab branch. Older `gh` versions and some non-TTY contexts emit informational lines on stdout alongside the URL; the unfiltered capture would seed JOURNAL.md with a multi-line value that subsequent validation rejects, leaving an orphan issue on GitHub.
+- **`pp solution-down|up` validates the picked solution number is in range** before indexing `${SOLUTIONS[$((pick-1))]}`. Previously typing `99` on a 2-solution config crashed with `unbound variable` instead of a friendly error.
+- **`pp setup` candidate display preserves paths with spaces.** `printf '  %s\n' $candidates` (unquoted) word-split on whitespace, mis-rendering paths under `~/Projects/Some Client/`. Now uses `printf '%s\n' "$candidates" | sed 's/^/  /'`.
+
+### Tests
+
+- Test runners (`test_load_project.sh`, `test_register_atomic.sh`) now use `trap cleanup_tmpdirs EXIT` so `mktemp -d` directories are removed even if the suite is interrupted (Ctrl-C, SIGTERM, mid-run failure).
+
+### Notes on findings investigated and dismissed
+
+- An audit claim that 4 markdown anchors with `--` (double dash) were broken turned out to be a **false positive**. GitHub's slugger does NOT collapse consecutive dashes — em-dash-with-spaces in a heading legitimately produces `--` in the slug. Verified against the actual GFM slug algorithm. The `#270--2026-04-29`, `#async-ui-updates--aria-live-regions`, `#documents--file-upload-limits` anchors are correct as shipped.
+
 ## [2.7.2] — 2026-04-29
 
 Follow-up patch surfacing five real bugs found by an independent post-release review. None are CVE-class — the v2.7.0 architectural fix is intact — but each is a real bug worth closing.
@@ -310,6 +331,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.7.3]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.3
 [2.7.2]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.2
 [2.7.1]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.1
 [2.7.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.0

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.7.2` by default)
+- Fetches the audit script from a pinned tag (`v2.7.3` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.7.2'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.7.3'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.2/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.3/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.2/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.3/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.7.2'   (recommended for production projects)
+#   AUDIT_REF:  'v2.7.3'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.7.2'
+  AUDIT_REF:  'v2.7.3'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -392,7 +392,10 @@ cmd_setup() {
     fi
 
     echo "Found:"
-    printf '  %s\n' $candidates
+    # Quote $candidates so paths with spaces stay one-per-line. The
+    # find pipeline produces newline-separated entries; bash word-
+    # splitting on unquoted $candidates would mis-print such paths.
+    printf '%s\n' "$candidates" | sed 's/^/  /'
     echo
     confirm_action "Walk through registering each candidate?"
 
@@ -679,10 +682,12 @@ cmd_down() {
     fi
 
     local total
-    total=$(git status -s 2>/dev/null | wc -l | tr -d ' ')
+    # `|| echo 0` guards against `git status` exiting non-zero (e.g. run
+    # from outside a git tree); pipefail would otherwise abort cmd_up.
+    total=$(git status -s 2>/dev/null | wc -l | tr -d ' ' || echo 0)
     echo
     info "Files changed: $total"
-    git status -s | head -30
+    git status -s 2>/dev/null | head -30 || true
     ok "Done. Review diffs and commit when ready."
 }
 
@@ -724,7 +729,7 @@ cmd_up() {
     local tracked untracked changed
     tracked=$(git diff --name-only HEAD -- "$SITE_DIR" 2>/dev/null || true)
     untracked=$(git ls-files --others --exclude-standard -- "$SITE_DIR" 2>/dev/null || true)
-    changed=$(printf '%s\n%s\n' "$tracked" "$untracked" | grep -v '^$' | sort -u | wc -l | tr -d ' ')
+    changed=$(printf '%s\n%s\n' "$tracked" "$untracked" | grep -v '^$' | sort -u | wc -l | tr -d ' ' || echo 0)
     info "Estimated changed files: $changed"
 
     if [ "$changed" -gt "$bulk_threshold" ] && [ "$force_bulk" = "0" ]; then
@@ -862,7 +867,7 @@ cmd_diff() {
         local label="$1" body="$2"
         [ -z "$body" ] && return 0
         local count
-        count=$(printf '%s' "$body" | grep -c .)
+        count=$(printf '%s' "$body" | grep -c . || echo 0)
         echo "${BOLD}$label${RST}  ($count)"
         printf '%s' "$body" | sed 's/^/  /'
         echo
@@ -952,7 +957,7 @@ cmd_doctor() {
     [ -f "$SITE_DIR/website.yml" ] && ok "website.yml present" || err "website.yml MISSING"
 
     local dirty branch
-    dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ' || echo 0)
     branch=$(git branch --show-current 2>/dev/null || echo "(none)")
     echo "  Branch:           $branch"
     echo "  Dirty files:      $dirty"
@@ -962,11 +967,13 @@ cmd_doctor() {
 
     echo
     echo "${BOLD}## Site content counts${RST}"
-    echo "  Web pages:        $(find "$SITE_DIR/web-pages" -name "*.webpage.yml" 2>/dev/null | wc -l | tr -d ' ')"
-    echo "  Web templates:    $(find "$SITE_DIR/web-templates" -name "*.webtemplate.source.html" 2>/dev/null | wc -l | tr -d ' ')"
-    echo "  Content snippets: $(find "$SITE_DIR/content-snippets" -name "*.contentsnippet.value.html" 2>/dev/null | wc -l | tr -d ' ')"
-    echo "  Table perms:      $(find "$SITE_DIR/table-permissions" -name "*.tablepermission.yml" 2>/dev/null | wc -l | tr -d ' ')"
-    echo "  Custom JS files:  $(find "$SITE_DIR/web-pages" "$SITE_DIR/web-files" -name "*.js" 2>/dev/null | wc -l | tr -d ' ')"
+    # `|| echo 0` guards each counter so that a missing subdir or a
+    # `find` quirk doesn't trip pipefail and abort doctor mid-report.
+    echo "  Web pages:        $(find "$SITE_DIR/web-pages" -name "*.webpage.yml" 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    echo "  Web templates:    $(find "$SITE_DIR/web-templates" -name "*.webtemplate.source.html" 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    echo "  Content snippets: $(find "$SITE_DIR/content-snippets" -name "*.contentsnippet.value.html" 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    echo "  Table perms:      $(find "$SITE_DIR/table-permissions" -name "*.tablepermission.yml" 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    echo "  Custom JS files:  $(find "$SITE_DIR/web-pages" "$SITE_DIR/web-files" -name "*.js" 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
     echo
     ok "Done."
 }
@@ -999,6 +1006,9 @@ cmd_solution_down() {
             local pick
             read -r -p "Pick number or name: " pick
             if [[ "$pick" =~ ^[0-9]+$ ]]; then
+                if [ "$pick" -lt 1 ] || [ "$pick" -gt "${#SOLUTIONS[@]}" ]; then
+                    die "Pick must be between 1 and ${#SOLUTIONS[@]}: got '$pick'"
+                fi
                 solution="${SOLUTIONS[$((pick-1))]}"
             else
                 solution="$pick"
@@ -1066,6 +1076,9 @@ cmd_solution_up() {
             local pick
             read -r -p "Pick number or name: " pick
             if [[ "$pick" =~ ^[0-9]+$ ]]; then
+                if [ "$pick" -lt 1 ] || [ "$pick" -gt "${#SOLUTIONS[@]}" ]; then
+                    die "Pick must be between 1 and ${#SOLUTIONS[@]}: got '$pick'"
+                fi
                 solution="${SOLUTIONS[$((pick-1))]}"
             else
                 solution="$pick"
@@ -1242,8 +1255,19 @@ cmd_sync_pages() {
 cmd_generate_page() {
     local input="${1:-}"
     local page_name="${2:-}"
-    [ -z "$input" ] || [ -z "$page_name" ] && die "Usage: pp generate-page <project> <Page-Name>"
-    
+    if [ -z "$input" ] || [ -z "$page_name" ]; then
+        die "Usage: pp generate-page <project> <Page-Name>"
+    fi
+
+    # Validate page_name before it flows into filenames + heredocs.
+    # Allows letters, numbers, spaces, dashes, underscores, dots — but
+    # rejects shell metacharacters AND path-traversal sequences (`..`,
+    # `/`, `\\`) that could escape the page directory.
+    validate_identifier "Page name" "$page_name" '^[A-Za-z0-9 _.-]+$'
+    case "$page_name" in
+        *..*|*/*|*\\*) die "Page name may not contain '..', '/', or backslash: '$page_name'" ;;
+    esac
+
     local name
     name=$(resolve_project "$input") || die "Unknown project: $input"
     load_project "$name"
@@ -1370,9 +1394,14 @@ EOF
             
             local issue_url=""
             if [ "$board_mode" = "github" ] && [ "$has_gh" = "1" ]; then
-                issue_url=$(gh issue create --title "$title" --body "Task initiated via pp-sync journal." --label "automated-journal" 2>/dev/null)
+                # Filter to just the issue URL — older `gh` versions and
+                # some non-TTY contexts emit informational lines to stdout
+                # alongside the URL. Mirrors the gitlab branch.
+                issue_url=$(gh issue create --title "$title" --body "Task initiated via pp-sync journal." --label "automated-journal" 2>/dev/null \
+                    | grep -oE 'https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/[0-9]+' | head -1 || true)
             elif [ "$board_mode" = "gitlab" ] && [ "$has_glab" = "1" ]; then
-                issue_url=$(glab issue create --title "$title" --description "Task initiated via pp-sync journal." 2>/dev/null | grep -o 'https://[^ ]*')
+                issue_url=$(glab issue create --title "$title" --description "Task initiated via pp-sync journal." 2>/dev/null \
+                    | grep -oE 'https://gitlab\.com/[A-Za-z0-9_./-]+/issues/[0-9]+' | head -1 || true)
             fi
 
             # Defense in depth: even though gh/glab created this URL on
@@ -1399,12 +1428,17 @@ EOF
             local attr=""
             [ "${AI_ATTR:-yes}" = "yes" ] && attr=" [AI-Assisted]"
 
-            # Validate the issue URL BEFORE writing anything to JOURNAL.md.
-            # If the URL is malformed or cross-repo, we abort with no
-            # side effects rather than leaving a stale note in the file.
+            # Find the URL written by the most recent `pp journal open`.
+            # Specifically match `^Issue: https://...` lines that the open
+            # subcommand writes — NOT arbitrary URLs that may appear in
+            # user notes (e.g. "see also https://other/repo/issues/5").
+            # This prevents lockout: a single inline cross-repo reference
+            # in a note used to make subsequent `note`/`close` permanently
+            # refuse to operate.
             local last_issue=""
             if [ -f "$REPO/JOURNAL.md" ]; then
-                last_issue=$(grep -oE 'https://(github|gitlab)\.com/[^ )]+' "$REPO/JOURNAL.md" | tail -1 || true)
+                last_issue=$(grep -E '^Issue: https://(github|gitlab)\.com/' "$REPO/JOURNAL.md" \
+                    | tail -1 | sed 's/^Issue: //' || true)
             fi
             if [ -n "$last_issue" ]; then
                 validate_issue_url_for_current_repo "$last_issue"
@@ -1427,11 +1461,13 @@ EOF
         close)
             local summary="${1:-}"
 
-            # Validate URL before writing the close marker (same rationale
-            # as note: avoid leaving stale entries when validation aborts).
+            # Same as `note`: only consider URLs written by `pp journal
+            # open` (lines beginning with `Issue: `), not arbitrary URLs
+            # in user-authored notes.
             local last_issue=""
             if [ -f "$REPO/JOURNAL.md" ]; then
-                last_issue=$(grep -oE 'https://(github|gitlab)\.com/[^ )]+' "$REPO/JOURNAL.md" | tail -1 || true)
+                last_issue=$(grep -E '^Issue: https://(github|gitlab)\.com/' "$REPO/JOURNAL.md" \
+                    | tail -1 | sed 's/^Issue: //' || true)
             fi
             if [ -n "$last_issue" ]; then
                 validate_issue_url_for_current_repo "$last_issue"

--- a/plugins/pp-sync/tests/test_load_project.sh
+++ b/plugins/pp-sync/tests/test_load_project.sh
@@ -22,6 +22,17 @@ PASS=0
 FAIL=0
 FAIL_NAMES=()
 
+# Each run_test creates a tmpdir; track them so a SIGINT/SIGTERM doesn't
+# leak temp directories under /tmp.
+TMPDIRS=()
+cleanup_tmpdirs() {
+    local tmp
+    for tmp in "${TMPDIRS[@]}"; do
+        rm -rf "$tmp"
+    done
+}
+trap cleanup_tmpdirs EXIT
+
 # Run a single test in a subshell so variable resets and aborts don't leak.
 # Args:
 #   $1: fixture name (basename without .conf)
@@ -31,6 +42,7 @@ run_test() {
     local fixture="$1" expect="$2" assertions="${3:-true}"
     local conf_dir
     conf_dir="$(mktemp -d)"
+    TMPDIRS+=( "$conf_dir" )
     mkdir -p "$conf_dir/projects"
     cp "$FIXTURES/$fixture.conf" "$conf_dir/projects/test.conf"
 

--- a/plugins/pp-sync/tests/test_register_atomic.sh
+++ b/plugins/pp-sync/tests/test_register_atomic.sh
@@ -19,10 +19,20 @@ PASS=0
 FAIL=0
 FAIL_NAMES=()
 
+TMPDIRS=()
+cleanup_tmpdirs() {
+    local tmp
+    for tmp in "${TMPDIRS[@]}"; do
+        rm -rf "$tmp"
+    done
+}
+trap cleanup_tmpdirs EXIT
+
 run_reject_test() {
     local label="$1" stdin="$2"
     local tmp
     tmp=$(mktemp -d)
+    TMPDIRS+=( "$tmp" )
     export PP_CONFIG_DIR="$tmp"
 
     local output exit_code
@@ -54,6 +64,7 @@ run_accept_test() {
     local label="$1" stdin="$2" expect_solutions="$3"
     local tmp
     tmp=$(mktemp -d)
+    TMPDIRS+=( "$tmp" )
     export PP_CONFIG_DIR="$tmp"
 
     local output exit_code

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.7.2"
+        "version": "2.7.3"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.0.1",
+        "pp-sync": "2.0.2",
         "pp-permissions-audit": "1.5.1"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.7.2"
+        "pp_permissions_audit_ci_ref": "v2.7.3"
     }
 }


### PR DESCRIPTION
Third review pass found 7 real bugs in pp subcommands the test suite hadn't exercised. None CVE-class.

| # | Severity | Fix |
|---|---|---|
| 1 | HIGH | `cmd_generate_page` validates page name (path traversal + YAML injection) |
| 2 | HIGH | `cmd_doctor`/`cmd_up`/`cmd_diff` no longer abort outside git tree (pipefail in `git status \| wc \| tr`) |
| 3 | HIGH | `cmd_journal note/close` find Issue: lines specifically, not any URL (cross-repo lock-out fix) |
| 4 | MEDIUM | `cmd_journal open` github branch filters URL (mirrors gitlab branch) |
| 5 | MEDIUM | `cmd_solution_down/up` validates pick in range (was: unbound variable crash) |
| 6 | MEDIUM | `cmd_setup` display preserves paths with spaces |
| 7 | LOW | Test runners use trap EXIT for tmpdir cleanup |

## Investigated, dismissed
- Claim that 4 markdown anchors with `--` were broken — false positive. GitHub does NOT collapse double dashes; em-dash-with-spaces in a heading legitimately produces `--` in the slug.

## Versions
Marketplace 2.7.2 → 2.7.3. pp-sync 2.0.1 → 2.0.2.