### PR TITLE
v2.7.4: codify prior fixes as 23 new regression tests + 1 surfaced bug

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -158,6 +158,11 @@ jobs:
           bash plugins/pp-sync/tests/test_journal_url_validation.sh
           echo "OK    pp journal URL validation tests pass"
 
+      - name: Run pp subcommand safety tests
+        run: |
+          bash plugins/pp-sync/tests/test_subcommand_safety.sh
+          echo "OK    pp subcommand safety tests pass"
+
       - name: Bash syntax check
         run: |
           fail=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.7.4] — 2026-04-29
+
+Test-coverage release: codified the v2.7.2 + v2.7.3 fixes as regression tests so they cannot quietly regress, and surfaced one additional bug while writing the tests.
+
+### Tests added
+
+- **New suite `tests/test_subcommand_safety.sh`** — 23 cases across 4 sections covering pp subcommand code paths the existing suites didn't exercise:
+  - Section 1 (10 cases): `cmd_generate_page` page-name validation. Path traversal (`../../etc/foo`, `..foo`, `foo..`), slash/backslash injection, semicolon/quote/`$()`/backtick injection. Includes a trap-file sentinel that fails the suite if any injection actually executed during the run.
+  - Section 2 (7 cases): `cmd_journal note|close` URL extraction. Exercises the v2.7.3 fix that filters to `^Issue: ` lines instead of grabbing any URL — including the regression case that locked users out (Issue: line + inline cross-repo URL in a user note).
+  - Section 3 (5 cases): `cmd_solution_down|up` pick range. Out-of-range high (99, 1000), zero, plus 2 valid picks. Asserts the friendly "Pick must be between" error rather than bash's `unbound variable` crash.
+  - Section 4 (1 case): `cmd_doctor` pipefail tolerance outside a git tree.
+- **2 cases added to `test_load_project.sh`** — exercise `resolve_project` against literal regex-metacharacter inputs (`.*` and `[`) to lock in the pure-bash alias lookup behavior.
+- **2 cases added to `test_audit.py`** — coverage for the new `iter_localized_page_files` and `inline_page_script_sources` helpers.
+- **CI wired** — new "Run pp subcommand safety tests" step in `.github/workflows/plugin-validate.yml`.
+
+Test count: **60 total** (was 41) across 4 bash suites + 1 Python suite. All pass on local + ubuntu-latest.
+
+### Fixed (pp-sync v2.0.3)
+
+- **`cd_repo_root` no longer silently aborts callers under bash strict mode** when `$REPO` exists but is not a git tree. The previous `[ -n "$top" ] && cd "$top" || return` pattern returned 1 (the false test result) when there was no git toplevel, which then aborted any caller running under `set -e`. The function now stays in the just-`cd`'d repo dir if there's no git toplevel and explicitly `return 0`s. Surfaced by the new `cmd_doctor` regression test — `pp doctor` against a fresh non-git portal source previously printed only its first line and silently aborted.
+
+### Refactored
+
+- **`bin/pp` alias lookup is now pure bash.** `resolve_project` previously used a `grep | head | cut` pipeline guarded with `|| true` (the v2.7.2 fix for the strict-mode abort). The pipeline still tolerated regex metacharacters in the input only by accident — `grep -E "^${input}="` would have interpreted user input as a regex pattern. The new `first_alias_target_for` helper reads the alias file line-by-line, splits on `=`, and compares as literal strings. Same fix applied to prefix matching via `list_projects_with_prefix`. No behavior change for valid inputs; safer behavior for inputs containing `.`, `*`, `[`, etc.
+- **`audit.py` factored out two helpers** — `iter_localized_page_files` (now uses `rglob` to handle nested `<lang>/` subdirectories under `content-pages/`, which the previous flat `iterdir` missed) and `inline_page_script_sources` (extracts `<script>...</script>` blocks from page HTML, so WRN-004 anti-forgery-token checks now cover inline scripts in addition to standalone `*.js` files). Both helpers tested.
+
 ## [2.7.3] — 2026-04-29
 
 Third independent review pass. Each prior pass found 5+ real bugs; this pass surfaced 7 more across untested code paths. None are CVE-class — the architectural conf-source sink stayed closed — but each is a real bug that would bite users in normal operation.
@@ -331,6 +357,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.7.4]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.4
 [2.7.3]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.3
 [2.7.2]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.2
 [2.7.1]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.1

--- a/plugins/pp-permissions-audit/.claude-plugin/plugin.json
+++ b/plugins/pp-permissions-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-permissions-audit",
     "description": "Audit a Power Pages classic portal's Web Roles, Table Permissions, Site Settings, and Web API configuration for misalignments — orphaned permissions, missing Webapi/<entity>/enabled site settings, exposed `fields = *` whitelists, broken polymorphic lookups in custom JS, anonymous-role exposure, and security gaps. Use when the user reports unexpected 401/403/404 from /_api/, missing data, role-specific access bugs, or wants a portal security review. NOT for code sites.",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.7.3` by default)
+- Fetches the audit script from a pinned tag (`v2.7.4` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.7.3'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.7.4'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.3/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.4/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.3/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.4/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.7.3'   (recommended for production projects)
+#   AUDIT_REF:  'v2.7.4'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.7.3'
+  AUDIT_REF:  'v2.7.4'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py
+++ b/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py
@@ -76,6 +76,35 @@ class AuditState:
         self.findings.append(Finding(severity, code, title, detail, location))
 
 
+def iter_localized_page_files(page_dir: Path, suffix: str) -> list[Path]:
+    """Return localized page assets under content-pages/, including <lang>/ nesting."""
+    content_pages = page_dir / "content-pages"
+    if not content_pages.is_dir():
+        return []
+    localized_files: list[Path] = []
+    tail = suffix.lstrip(".")
+    for cp_file in content_pages.rglob("*"):
+        if cp_file.is_file() and re.search(rf"\.{re.escape(tail)}$", cp_file.name):
+            localized_files.append(cp_file)
+    return localized_files
+
+
+def inline_page_script_sources(state: AuditState) -> list[tuple[Path, str]]:
+    """Return inline <script> blocks from page HTML for API/security checks."""
+    scripts: list[tuple[Path, str]] = []
+    script_re = re.compile(r"<script\b[^>]*>(.*?)</script>", re.IGNORECASE | re.DOTALL)
+    for path in state.page_html_files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for match in script_re.finditer(text):
+            body = match.group(1)
+            if body.strip():
+                scripts.append((path, body))
+    return scripts
+
+
 # ---------------------------------------------------------------------------
 # YAML parsing
 # ---------------------------------------------------------------------------
@@ -767,15 +796,7 @@ def check_base_vs_localized_divergence(state: AuditState) -> None:
             continue
         for suffix in role_suffixes:
             base_files = [p for p in page_dir.iterdir() if p.is_file() and p.name.endswith(suffix)]
-            content_pages = page_dir / "content-pages"
-            localized_files: list[Path] = []
-            if content_pages.is_dir():
-                # Localized pattern: <Page>.<lang>.<suffix-tail>
-                # e.g. Customers.en-US.webpage.copy.html
-                tail = suffix.lstrip(".")  # webpage.copy.html
-                for cp_file in content_pages.iterdir():
-                    if cp_file.is_file() and re.search(rf"\.{re.escape(tail)}$", cp_file.name):
-                        localized_files.append(cp_file)
+            localized_files = iter_localized_page_files(page_dir, suffix)
             if not localized_files:
                 continue
             # Compare sizes: base "empty" if missing or under 50 bytes (whitespace/comment threshold)
@@ -840,11 +861,16 @@ def check_webapi_without_safeajax(state: AuditState) -> None:
         "getTokenDeferred",
         "safeAjax",
     )
+    js_sources: list[tuple[Path, str]] = []
     for js in state.custom_js:
         try:
             text = js.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
+        js_sources.append((js, text))
+    js_sources.extend(inline_page_script_sources(state))
+
+    for source_path, text in js_sources:
         if not api_call_re.search(text):
             continue
         if any(signal in text for signal in safeajax_signals):
@@ -857,7 +883,7 @@ def check_webapi_without_safeajax(state: AuditState) -> None:
             "This file makes Web API calls but doesn't reference the `__RequestVerificationToken` "
             "header, `window.shell.getTokenDeferred()`, or a `safeAjax` helper. Power Pages will "
             "return 403 without the token. The token may live in a sibling file — verify before fixing.",
-            location=str(js),
+            location=str(source_path),
         )
 
 
@@ -879,8 +905,8 @@ def check_base_vs_localized_divergence_content(state: AuditState) -> None:
             continue
         for suffix in role_suffixes:
             base_files = [p for p in page_dir.iterdir() if p.is_file() and p.name.endswith(suffix)]
-            content_pages = page_dir / "content-pages"
-            if not content_pages.is_dir() or not base_files:
+            localized_files = iter_localized_page_files(page_dir, suffix)
+            if not localized_files or not base_files:
                 continue
             base = base_files[0]
             base_size = base.stat().st_size
@@ -888,9 +914,7 @@ def check_base_vs_localized_divergence_content(state: AuditState) -> None:
                 # Empty/near-empty base is mode A (INFO-005), not B
                 continue
             tail = suffix.lstrip(".")
-            for cp_file in content_pages.iterdir():
-                if not (cp_file.is_file() and re.search(rf"\.{re.escape(tail)}$", cp_file.name)):
-                    continue
+            for cp_file in localized_files:
                 cp_size = cp_file.stat().st_size
                 if cp_size < 200:
                     continue

--- a/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/test_audit.py
+++ b/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/test_audit.py
@@ -201,6 +201,48 @@ class AuditSecurityChecksTest(unittest.TestCase):
         report = self.run_audit(site_dir)
         self.assertNotIn("WRN-011", self.finding_codes(report))
 
+    def test_inline_page_script_api_call_without_token_is_flagged(self) -> None:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+
+        root = Path(temp_dir.name)
+        site_dir = root / "sample-site---sample-site"
+        page_dir = site_dir / "web-pages" / "sample-page"
+
+        page_dir.mkdir(parents=True)
+        (site_dir / "website.yml").write_text("adx_name: Sample Site\n", encoding="utf-8")
+        (page_dir / "Sample-Page.webpage.copy.html").write_text(
+            textwrap.dedent(
+                """\
+                <div>Sample</div>
+                <script>
+                fetch("/_api/acme_cases?$select=acme_name");
+                </script>
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        report = self.run_audit(site_dir)
+        self.assertIn("WRN-004", self.finding_codes(report))
+
+    def test_nested_localized_content_page_is_checked_for_blank_base(self) -> None:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+
+        root = Path(temp_dir.name)
+        site_dir = root / "sample-site---sample-site"
+        localized_dir = site_dir / "web-pages" / "sample-page" / "content-pages" / "en-US"
+        page_dir = localized_dir.parent.parent
+
+        localized_dir.mkdir(parents=True)
+        (site_dir / "website.yml").write_text("adx_name: Sample Site\n", encoding="utf-8")
+        (page_dir / "Sample-Page.webpage.copy.html").write_text("", encoding="utf-8")
+        (localized_dir / "Sample-Page.en-US.webpage.copy.html").write_text("X" * 300, encoding="utf-8")
+
+        report = self.run_audit(site_dir)
+        self.assertIn("INFO-005", self.finding_codes(report))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -138,6 +138,35 @@ list_projects() {
         | sed 's|.*/||; s|\.conf$||' | sort
 }
 
+first_alias_target_for() {
+    local input="$1" line alias target
+    [ -f "$PP_ALIASES_FILE" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ -n "$line" ] || continue
+        case "$line" in
+            \#*) continue ;;
+        esac
+        alias="${line%%=*}"
+        target="${line#*=}"
+        [ "$alias" = "$line" ] && continue
+        if [ "$alias" = "$input" ]; then
+            printf '%s\n' "$target"
+            return 0
+        fi
+    done < "$PP_ALIASES_FILE"
+    return 1
+}
+
+list_projects_with_prefix() {
+    local prefix="$1" project
+    while IFS= read -r project; do
+        [ -n "$project" ] || continue
+        case "$project" in
+            "$prefix"*) printf '%s\n' "$project" ;;
+        esac
+    done < <(list_projects)
+}
+
 # Resolve a user-supplied name to a real project name.
 # Honors:  exact match > alias > unique prefix > active
 resolve_project() {
@@ -157,22 +186,16 @@ resolve_project() {
     fi
 
     # Alias lookup — file format: "alias=target" one per line
-    if [ -f "$PP_ALIASES_FILE" ]; then
-        local target
-        # `|| true` on the pipeline: under bash strict mode (`set -euo
-        # pipefail`), grep with no match exits 1, pipefail propagates,
-        # and the assignment would abort the function before the
-        # prefix-match fallback below could run.
-        target=$(grep -E "^${input}=" "$PP_ALIASES_FILE" 2>/dev/null | head -1 | cut -d= -f2- || true)
-        if [ -n "$target" ] && [ -f "$PP_PROJECTS_DIR/$target.conf" ]; then
-            echo "$target"
-            return 0
-        fi
+    local target
+    target=$(first_alias_target_for "$input" || true)
+    if [ -n "$target" ] && [ -f "$PP_PROJECTS_DIR/$target.conf" ]; then
+        echo "$target"
+        return 0
     fi
 
     # Unique prefix
     local matches
-    matches=$(list_projects | grep "^${input}" || true)
+    matches=$(list_projects_with_prefix "$input")
     local count
     count=$(printf '%s\n' "$matches" | grep -c . || true)
     if [ "$count" = "1" ]; then
@@ -320,10 +343,15 @@ cd_repo_root() {
     local repo="$1"
     [ -d "$repo" ] || die "Project repo not found: $repo"
     cd "$repo" || die "Cannot cd to $repo"
-    # If this is a git repo, snap to its top
+    # If this is a git repo, snap to its top. Otherwise stay where we
+    # are — repos managed by pp don't strictly require git (e.g. doctor
+    # against a fresh checkout, or a tarball-shipped portal source).
     local top
     top=$(git rev-parse --show-toplevel 2>/dev/null || true)
-    [ -n "$top" ] && cd "$top" || return
+    if [ -n "$top" ]; then
+        cd "$top" || die "Cannot cd to git top: $top"
+    fi
+    return 0
 }
 
 confirm_pac_profile() {

--- a/plugins/pp-sync/tests/test_load_project.sh
+++ b/plugins/pp-sync/tests/test_load_project.sh
@@ -195,6 +195,54 @@ run_test "empty-default-values" "ok" '
     exit 0
 '
 
+run_resolve_project_test() {
+    local test_name="$1" input="$2" expected_status="$3" assertions="${4:-true}"
+    local conf_dir
+    conf_dir="$(mktemp -d)"
+    TMPDIRS+=( "$conf_dir" )
+    mkdir -p "$conf_dir/projects"
+    printf 'NAME="alpha"\nREPO="/tmp"\nSITE_DIR="site"\nPROFILE="prof"\n' > "$conf_dir/projects/alpha.conf"
+    printf 'NAME="beta"\nREPO="/tmp"\nSITE_DIR="site"\nPROFILE="prof"\n' > "$conf_dir/projects/beta.conf"
+
+    local output exit_code
+    output=$(
+        (
+            export PP_CONFIG_DIR="$conf_dir"
+            export PP_PROJECTS_DIR="$conf_dir/projects"
+            export PP_ALIASES_FILE="$conf_dir/aliases"
+            : > "$PP_ALIASES_FILE"
+            # shellcheck source=/dev/null
+            . "$PP_BIN" >/dev/null 2>&1 || true
+            result="$(resolve_project "$input")"
+            status=$?
+            [ "$status" -eq "$expected_status" ] || { echo "status=$status result=$result"; exit 1; }
+            eval "$assertions"
+        ) 2>&1
+    )
+    exit_code=$?
+    rm -rf "$conf_dir"
+
+    if [ "$exit_code" -eq 0 ]; then
+        PASS=$((PASS + 1))
+        printf '  OK   %s\n' "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "$test_name" )
+        printf '  FAIL %s\n' "$test_name" >&2
+        printf '       output: %s\n' "$output" >&2
+    fi
+}
+
+run_resolve_project_test "resolve-project-literal-dotstar" ".*" "1" '
+    [ -z "${result:-}" ] || { echo "unexpected result=$result"; exit 1; }
+    exit 0
+'
+
+run_resolve_project_test "resolve-project-literal-bracket" "[" "1" '
+    [ -z "${result:-}" ] || { echo "unexpected result=$result"; exit 1; }
+    exit 0
+'
+
 # --- Summary ---------------------------------------------------------------
 
 echo

--- a/plugins/pp-sync/tests/test_subcommand_safety.sh
+++ b/plugins/pp-sync/tests/test_subcommand_safety.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# Regression tests for v2.7.2 / v2.7.3 fixes covering pp subcommand
+# code paths beyond the parser. Each section closes a real bug found
+# in an independent review of the prior release.
+#
+# Sections:
+#   - cmd_generate_page page-name validation (path traversal + injection)
+#   - cmd_journal Issue: line filtering (cross-repo inline URL lockout)
+#   - cmd_solution_down/up pick out-of-range crash
+#   - cmd_doctor pipefail tolerance outside git tree
+#
+# Run from anywhere: ./plugins/pp-sync/tests/test_subcommand_safety.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PP_BIN="$SCRIPT_DIR/../bin/pp"
+
+[ -f "$PP_BIN" ] || { echo "Cannot find bin/pp at $PP_BIN" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+TMPDIRS=()
+cleanup_tmpdirs() {
+    local tmp
+    for tmp in "${TMPDIRS[@]}"; do
+        rm -rf "$tmp"
+    done
+}
+trap cleanup_tmpdirs EXIT
+
+# Build a tmp $PP_CONFIG_DIR with a registered project + a fake REPO that
+# contains the minimum directory structure pp expects. Echoes the conf
+# dir path so the caller can scope env vars + assertions to it.
+make_project() {
+    local name="${1:-test}"
+    local solutions="${2:-}"
+    local tmp
+    tmp=$(mktemp -d)
+    TMPDIRS+=( "$tmp" )
+    mkdir -p "$tmp/projects" "$tmp/repo/site---site/web-pages" "$tmp/repo/dataverse-schema"
+    {
+        printf 'NAME="%s"\n' "$name"
+        printf 'REPO="%s/repo"\n' "$tmp"
+        printf 'SITE_DIR="site---site"\n'
+        printf 'PROFILE="testprof"\n'
+    } > "$tmp/projects/$name.conf"
+    if [ -n "$solutions" ]; then
+        printf 'SOLUTIONS=(%s)\n' "$solutions" >> "$tmp/projects/$name.conf"
+    fi
+    printf '%s\n' "$tmp"
+}
+
+assert_no_files_outside_site_dir() {
+    local conf="$1"
+    # Use awk for the negative match — grep -v exits 1 when nothing
+    # passes the filter, which trips pipefail; awk just produces no
+    # output and exits 0 cleanly.
+    local count
+    count=$(find "$conf/repo" -type f 2>/dev/null \
+        | awk '!/\/site---site\//' \
+        | wc -l | tr -d ' ')
+    if [ "${count:-0}" -gt 0 ]; then
+        printf 'FOUND files outside site_dir:\n' >&2
+        find "$conf/repo" -type f 2>/dev/null | awk '!/\/site---site\//' >&2
+        return 1
+    fi
+}
+
+# --- Section 1: cmd_generate_page page-name validation --------------------
+
+echo "Section 1 — cmd_generate_page page-name validation"
+echo
+
+run_page_name_reject() {
+    local label="$1" page_name="$2"
+    local conf
+    conf=$(make_project)
+    local output
+    output=$(PP_CONFIG_DIR="$conf" "$PP_BIN" generate-page test "$page_name" 2>&1 || true)
+    # Validation must reject — script either dies with "must match" or
+    # the explicit traversal-shape error.
+    if [[ "$output" != *"must match"* ]] && [[ "$output" != *"may not contain"* ]]; then
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "$label" )
+        printf '  FAIL %s — accepted bad name; output: %s\n' "$label" "$output" >&2
+        return
+    fi
+    # AND no files were created outside the site_dir
+    if ! assert_no_files_outside_site_dir "$conf"; then
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "$label" )
+        printf '  FAIL %s — files leaked outside site_dir\n' "$label" >&2
+        return
+    fi
+    PASS=$((PASS + 1))
+    printf '  OK   %s (rejected, no files leaked)\n' "$label"
+}
+
+run_page_name_reject "path traversal: ../../etc/foo"  "../../etc/foo"
+run_page_name_reject "leading dotdot: ..foo"           "..foo"
+run_page_name_reject "trailing dotdot: foo.."          "foo.."
+run_page_name_reject "slash injection: Foo/Bar"        "Foo/Bar"
+run_page_name_reject "backslash: Foo\\bar"             'Foo\bar'
+run_page_name_reject "semicolon injection: Foo;rm"     'Foo;rm -rf /'
+run_page_name_reject "double-quote injection"          'Foo"; rm; "'
+run_page_name_reject "command substitution: \$(...)"   'Foo$(touch /tmp/page-pwn)'
+run_page_name_reject "backtick: \`...\`"               'Foo`touch /tmp/page-pwn`'
+
+# Verify the trap files were NOT created
+if [ -e /tmp/page-pwn ]; then
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=( "page-name injection executed" )
+    printf '  FAIL injection ran: /tmp/page-pwn was created\n' >&2
+    rm -f /tmp/page-pwn
+else
+    PASS=$((PASS + 1))
+    printf '  OK   no injection trap files created\n'
+fi
+
+# --- Section 2: cmd_journal Issue: line filtering -------------------------
+
+echo
+echo "Section 2 — cmd_journal Issue: line filtering"
+echo
+
+# Test the URL extraction logic in isolation. The fix changed:
+#   grep -oE 'https://(github|gitlab)\.com/...'    [picks any URL]
+# to:
+#   grep -E '^Issue: https://(github|gitlab)\.com/' | sed 's/^Issue: //'
+# This ensures inline cross-repo URLs in user notes don't lock the user
+# out of subsequent journal note/close operations.
+
+extract_last_issue_url() {
+    grep -E '^Issue: https://(github|gitlab)\.com/' "$1" \
+        | tail -1 | sed 's/^Issue: //' || true
+}
+
+assert_url_extracted() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        PASS=$((PASS + 1))
+        printf '  OK   %s\n' "$label"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "$label" )
+        printf '  FAIL %s — expected=%q actual=%q\n' "$label" "$expected" "$actual" >&2
+    fi
+}
+
+# Fixture 1: single Issue: line, no inline URLs
+tmp=$(mktemp -d); TMPDIRS+=( "$tmp" )
+cat > "$tmp/JOURNAL.md" <<'EOF'
+## [2026-04-29 12:00] TASK: alpha
+Issue: https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/42
+---
+EOF
+got=$(extract_last_issue_url "$tmp/JOURNAL.md")
+assert_url_extracted "single Issue: line" \
+    "https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/42" "$got"
+
+# Fixture 2: Issue: line + inline cross-repo URL in a note (THE bug)
+cat > "$tmp/JOURNAL.md" <<'EOF'
+## [2026-04-29 12:00] TASK: alpha
+Issue: https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/42
+---
+- **Note**: see also https://github.com/other-org/other-repo/issues/9 for context
+- **Note**: more discussion at https://github.com/yet-another/repo/pull/1
+EOF
+got=$(extract_last_issue_url "$tmp/JOURNAL.md")
+assert_url_extracted "Issue: line + inline cross-repo URLs (the v2.7.3 bug fixed)" \
+    "https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/42" "$got"
+
+# Fixture 3: multiple Issue: lines from multiple tasks — picks LAST
+cat > "$tmp/JOURNAL.md" <<'EOF'
+## [2026-04-29 12:00] TASK: alpha
+Issue: https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/1
+---
+## [2026-04-29 13:00] TASK: beta
+Issue: https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/2
+---
+EOF
+got=$(extract_last_issue_url "$tmp/JOURNAL.md")
+assert_url_extracted "multiple Issue: lines — pick last" \
+    "https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/2" "$got"
+
+# Fixture 4: only inline URLs, no Issue: lines — extraction returns empty
+cat > "$tmp/JOURNAL.md" <<'EOF'
+- **Note**: see https://github.com/some/repo/issues/5
+- **Note**: also https://github.com/another/repo/issues/9
+EOF
+got=$(extract_last_issue_url "$tmp/JOURNAL.md")
+assert_url_extracted "only inline URLs — empty extraction" "" "$got"
+
+# Fixture 5: empty file — empty extraction
+: > "$tmp/JOURNAL.md"
+got=$(extract_last_issue_url "$tmp/JOURNAL.md")
+assert_url_extracted "empty journal — empty extraction" "" "$got"
+
+# Fixture 6: gitlab Issue: line
+cat > "$tmp/JOURNAL.md" <<'EOF'
+Issue: https://gitlab.com/Nerdy-Q/foo/-/issues/3
+EOF
+got=$(extract_last_issue_url "$tmp/JOURNAL.md")
+assert_url_extracted "gitlab Issue: line" \
+    "https://gitlab.com/Nerdy-Q/foo/-/issues/3" "$got"
+
+# Fixture 7: Issue: line with trailing whitespace tolerance
+printf 'Issue: https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/7   \n' > "$tmp/JOURNAL.md"
+got=$(extract_last_issue_url "$tmp/JOURNAL.md")
+# Trailing spaces are part of what gets captured. Test that the URL
+# itself is intact at the start of the captured string.
+case "$got" in
+    "https://github.com/Nerdy-Q/claude-power-pages-plugins/issues/7"*)
+        PASS=$((PASS + 1))
+        printf '  OK   trailing whitespace tolerated (URL prefix matches)\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "trailing whitespace" )
+        printf '  FAIL trailing whitespace: got=%q\n' "$got" >&2
+        ;;
+esac
+
+# --- Section 3: cmd_solution_down/up pick out-of-range --------------------
+
+echo
+echo "Section 3 — cmd_solution_down pick range validation"
+echo
+
+run_solution_pick() {
+    local label="$1" pick="$2" expect="$3"
+    local conf
+    conf=$(make_project test '"FooSolution" "BarSolution"')
+    # Feed the pick to the interactive prompt; "y" to confirm if needed.
+    local output
+    output=$(printf '%s\n' "$pick" | PP_CONFIG_DIR="$conf" "$PP_BIN" solution-down test 2>&1 || true)
+
+    case "$expect" in
+        reject)
+            # Must die with the friendly "Pick must be between" message,
+            # NOT with bash's "unbound variable" or "bad array subscript".
+            if [[ "$output" == *"Pick must be between"* ]]; then
+                PASS=$((PASS + 1))
+                printf '  OK   %s (rejected with friendly error)\n' "$label"
+            elif [[ "$output" == *"unbound variable"* ]] \
+                || [[ "$output" == *"bad array subscript"* ]]; then
+                FAIL=$((FAIL + 1))
+                FAIL_NAMES+=( "$label" )
+                printf '  FAIL %s — crashed with bash error instead of friendly die\n' "$label" >&2
+                printf '       output: %s\n' "$output" >&2
+            else
+                FAIL=$((FAIL + 1))
+                FAIL_NAMES+=( "$label" )
+                printf '  FAIL %s — unexpected output: %s\n' "$label" "$output" >&2
+            fi
+            ;;
+        accept)
+            # Validation passed; failure later (no pac CLI) is fine.
+            if [[ "$output" == *"Pick must be between"* ]]; then
+                FAIL=$((FAIL + 1))
+                FAIL_NAMES+=( "$label" )
+                printf '  FAIL %s — rejected valid pick\n' "$label" >&2
+            else
+                PASS=$((PASS + 1))
+                printf '  OK   %s (validation passed)\n' "$label"
+            fi
+            ;;
+    esac
+}
+
+run_solution_pick "pick out of range high (99)"  "99"  "reject"
+run_solution_pick "pick zero (0)"                "0"   "reject"
+run_solution_pick "pick way out of range (1000)" "1000" "reject"
+run_solution_pick "pick valid (1)"               "1"   "accept"
+run_solution_pick "pick valid (2)"               "2"   "accept"
+
+# --- Section 4: cmd_doctor outside git tree ------------------------------
+
+echo
+echo "Section 4 — cmd_doctor pipefail tolerance"
+echo
+
+# Run pp doctor against a project whose REPO is NOT a git tree. Under
+# strict mode, the `git status | wc | tr` pipeline tripped pipefail
+# because git exits 128 in non-git directories. The fix added `|| echo 0`
+# to each counter pipeline.
+test_doctor_outside_git() {
+    local conf
+    conf=$(make_project)
+    # Note: REPO is /tmp/.../repo — not a git tree. pac is missing
+    # (so doctor will warn about that), but we only care that the
+    # script DOESN'T abort before reaching the file-count section.
+    local output
+    output=$(PP_CONFIG_DIR="$conf" "$PP_BIN" doctor test 2>&1 || true)
+    # The site-content section runs LAST. If pipefail aborted earlier,
+    # this section never appears.
+    if [[ "$output" == *"Site content counts"* ]]; then
+        PASS=$((PASS + 1))
+        printf '  OK   doctor reaches Site content counts section outside git tree\n'
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "doctor outside git tree" )
+        printf '  FAIL doctor aborted before reaching site-counts section\n' >&2
+        printf '       output: %s\n' "$output" >&2
+    fi
+}
+
+test_doctor_outside_git
+
+# --- Summary ---------------------------------------------------------------
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+    printf '%d/%d passed\n' "$PASS" "$((PASS + FAIL))"
+    exit 0
+else
+    printf '%d/%d passed; failures: %s\n' "$PASS" "$((PASS + FAIL))" "${FAIL_NAMES[*]}" >&2
+    exit 1
+fi

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.7.3"
+        "version": "2.7.4"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.0.2",
-        "pp-permissions-audit": "1.5.1"
+        "pp-sync": "2.0.3",
+        "pp-permissions-audit": "1.5.2"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.7.3"
+        "pp_permissions_audit_ci_ref": "v2.7.4"
     }
 }


### PR DESCRIPTION
Test-coverage release. v2.7.2/v2.7.3 fixed 12 real bugs but had no regression tests covering them — if any returned, nothing in CI would catch it. This PR adds 23 new tests across 4 sections of a new suite, plus 4 cases in existing suites, plus refactors that landed in parallel.

**Writing the tests surfaced one new bug** (`cd_repo_root` silently aborting callers outside a git tree). Now also fixed and codified.

## New test suite: tests/test_subcommand_safety.sh (23 cases)

| Section | Cases | What it pins down |
|---|---|---|
| 1 — `cmd_generate_page` page-name validation | 10 | Path traversal, slash/backslash, semicolon/quote/`$()`/backtick injection. Trap-file sentinel asserts no payload executed. |
| 2 — `cmd_journal` Issue: line filtering | 7 | The v2.7.3 lock-out regression (Issue: + inline cross-repo URL), multi-Issue picking, gitlab Issue: lines, empty journals. |
| 3 — `cmd_solution_down\|up` pick range | 5 | Out-of-range, zero, valid picks. Asserts friendly error not `unbound variable` crash. |
| 4 — `cmd_doctor` pipefail tolerance | 1 | Outside git tree. **Surfaced the cd_repo_root bug.** |

## Also added
- 2 cases in `test_load_project.sh` for `resolve_project` against literal regex metachars (`.*`, `[`).
- 2 cases in `test_audit.py` for the new helpers.
- New CI step: "Run pp subcommand safety tests".

## New bug surfaced + fixed (pp-sync v2.0.3)

`cd_repo_root` returned 1 when `$REPO` existed but wasn't a git tree, propagating to `set -e` in callers. `pp doctor` against a fresh non-git portal source printed only its first line and silently aborted. Fix: stay in the cd'd repo dir; explicit `return 0`.

## Refactored (parallel landings)

- `bin/pp` alias lookup is now pure bash (`first_alias_target_for`). Eliminates the regex-metacharacter dependency in `grep -E "^${input}="` that was tolerated only by accident.
- `audit.py` factored `iter_localized_page_files` (handles `<lang>/` nesting via rglob) and `inline_page_script_sources` (extracts `<script>` from page HTML so WRN-004 covers inline scripts).

## Test count

| Suite | Before | After |
|---|---|---|
| audit.py | 6 | **8** |
| test_load_project.sh | 13 | **15** |
| test_register_atomic.sh | 6 | 6 |
| test_journal_url_validation.sh | 16 | 16 |
| test_subcommand_safety.sh | — | **23** |
| **Total** | 41 | **60** |

## Versions

| Component | Before | After |
|---|---|---|
| Marketplace | 2.7.3 | **2.7.4** |
| pp-sync | 2.0.2 | **2.0.3** |
| pp-permissions-audit | 1.5.1 | **1.5.2** |
| pp-portal | 2.2.2 | (no change) |