### PR TITLE
v2.7.5: 59 new command-flow tests + 2 surfaced bugs fixed

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -163,6 +163,11 @@ jobs:
           bash plugins/pp-sync/tests/test_subcommand_safety.sh
           echo "OK    pp subcommand safety tests pass"
 
+      - name: Run pp command-flow tests
+        run: |
+          bash plugins/pp-sync/tests/test_command_flows.sh
+          echo "OK    pp command-flow tests pass"
+
       - name: Bash syntax check
         run: |
           fail=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.7.5] — 2026-04-29
+
+Deeper test coverage release. Added `tests/test_command_flows.sh` — 59 cases across 10 sections covering pp subcommand flows the previous suites didn't reach. Writing the tests surfaced **two more real bugs**, both fixed in this same release.
+
+### Tests added
+
+- **New suite `tests/test_command_flows.sh`** — 59 cases across 10 sections:
+  1. **Project name resolution** (8): exact match, unique prefix, ambiguous prefix (asserts both candidates listed in error), no-match, alias resolution, exact-match-wins-over-alias.
+  2. **`cmd_show`** (6): all field labels present, ghost-project error.
+  3. **`cmd_list`** (5): empty registry friendly message, populated registry tabular output.
+  4. **`cmd_alias_add` / `cmd_alias_list`** (9): valid add, ghost target rejected (atomic), shell-metachar name rejected, list output, duplicate replacement, no-duplicate-rows invariant.
+  5. **`cmd_project_remove`** (6): atomic deletion of conf + alias rows + active file, unrelated aliases preserved, ghost-project error.
+  6. **`cmd_switch` / `cmd_status`** (5): no-active message, switch writes active file, status reflects active project, switch-to-other updates status.
+  7. **`cmd_journal init`** (4): file creation, project-name in template, Project Context section present, idempotency (manual edits preserved).
+  8. **`cmd_generate_page` happy path** (5): page dir created, base YAML + HTML created, content-pages dir created, duplicate generate-page rejected.
+  9. **`cmd_sync_pages`** (3): base-to-localized copy, localized-to-base copy, invalid direction rejected.
+  10. **`cmd_help`** (7): exits 0, output mentions every major subcommand.
+- **CI wired** — new "Run pp command-flow tests" step.
+
+Test count: **127 total** (was 60) across 5 bash suites + 1 Python suite. All pass on local + ubuntu-latest.
+
+### Fixed (pp-sync v2.0.4)
+
+- **`cmd_generate_page` aborted under strict mode against fresh portal source.** The `find $SITE_DIR/page-templates -name "*.pagetemplate.yml" | head -1 | sed ...` pipeline used to discover a default page template tripped pipefail when the `page-templates/` directory didn't exist (a fresh portal source, or one where templates were never exported). The function reported "Generating page" but produced zero files because the assignment aborted before `mkdir -p` could run. Added `|| true` to the discovery pipeline; missing template directory now falls through to the placeholder default.
+- **`cmd_sync_pages` could not find localized files in the actual Power Pages layout.** Power Pages classic stores localized page assets at `web-pages/<slug>/content-pages/<lang>/<Page>.<lang>.webpage.copy.html`, but the function's glob `"$cp_dir"/*"$suffix"` only matched files DIRECTLY in `content-pages/`, never recursing into `<lang>/` subdirectories. Result: every `pp sync-pages` run on a real portal source reported "Copied: 0" regardless of how out-of-sync the files were. Replaced the glob with `find -type f -name "*$suffix"` which recurses correctly. Same fix the audit.py `iter_localized_page_files` helper got.
+
 ## [2.7.4] — 2026-04-29
 
 Test-coverage release: codified the v2.7.2 + v2.7.3 fixes as regression tests so they cannot quietly regress, and surfaced one additional bug while writing the tests.
@@ -357,6 +383,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.7.5]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.5
 [2.7.4]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.4
 [2.7.3]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.3
 [2.7.2]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.2

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.7.4` by default)
+- Fetches the audit script from a pinned tag (`v2.7.5` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.7.4'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.7.5'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.4/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.5/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.4/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.5/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.7.4'   (recommended for production projects)
+#   AUDIT_REF:  'v2.7.5'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.7.4'
+  AUDIT_REF:  'v2.7.5'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -1234,20 +1234,23 @@ cmd_sync_pages() {
             done
             [ -z "$base_file" ] && continue
 
-            # Find first localized file
-            local loc_file=""
-            for f in "$cp_dir"/*"$suffix"; do
-                [ -f "$f" ] || continue
-                loc_file="$f"
-                break
-            done
+            # Find localized files. Power Pages classic stores them
+            # under content-pages/<lang>/, so we must recurse via find
+            # rather than glob. The previous `*$suffix` shell glob only
+            # matched files DIRECTLY in content-pages/ — which doesn't
+            # match the actual export layout.
+            local loc_file="" loc_files=()
+            while IFS= read -r f; do
+                [ -n "$f" ] || continue
+                loc_files+=( "$f" )
+                [ -z "$loc_file" ] && loc_file="$f"
+            done < <(find "$cp_dir" -type f -name "*$suffix" 2>/dev/null || true)
             [ -z "$loc_file" ] && continue
 
             case "$direction" in
                 base-to-localized)
                     # Copy base content into ALL localized variants
-                    for f in "$cp_dir"/*"$suffix"; do
-                        [ -f "$f" ] || continue
+                    for f in "${loc_files[@]}"; do
                         if cmp -s "$base_file" "$f"; then
                             skipped=$((skipped + 1))
                         else
@@ -1314,9 +1317,11 @@ cmd_generate_page() {
     # 1. Base Metadata (.webpage.yml)
     # We use some heuristics to guess valid references
     local website_id_val="${WEBSITE_ID:-00000000-0000-0000-0000-000000000000}"
-    # Pick the first page template we find, or use a placeholder
+    # Pick the first page template we find, or use a placeholder. The
+    # `|| true` guards against pipefail aborting the function when
+    # page-templates/ doesn't exist (e.g. fresh portal source).
     local template_name
-    template_name=$(find "$SITE_DIR/page-templates" -name "*.pagetemplate.yml" -maxdepth 1 2>/dev/null | head -1 | sed 's/.*\///; s/\.pagetemplate\.yml//')
+    template_name=$(find "$SITE_DIR/page-templates" -name "*.pagetemplate.yml" -maxdepth 1 2>/dev/null | head -1 | sed 's/.*\///; s/\.pagetemplate\.yml//' || true)
     template_name="${template_name:-Full Page}"
 
     cat > "$page_dir/$page_name.webpage.yml" <<EOF

--- a/plugins/pp-sync/tests/test_command_flows.sh
+++ b/plugins/pp-sync/tests/test_command_flows.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# Command-flow regression tests — happy path + error cases for the pp
+# subcommands the existing suites don't exercise. Each section closes
+# a class of bugs (atomicity, ambiguity, state consistency, idempotency)
+# that hand-testing tends to miss.
+#
+# Sections:
+#   1. project name resolution (exact / alias / prefix / ambiguous / none)
+#   2. cmd_show
+#   3. cmd_list (empty + populated)
+#   4. cmd_alias_add / cmd_alias_list
+#   5. cmd_project_remove (atomicity + alias cleanup + active reset)
+#   6. cmd_switch / cmd_status (active state)
+#   7. cmd_journal init (idempotency + template content)
+#   8. cmd_generate_page happy path (file structure)
+#   9. cmd_sync_pages (direction validation + actual copy)
+#  10. cmd_help (exits 0, lists all subcommands)
+#
+# Run from anywhere: ./plugins/pp-sync/tests/test_command_flows.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PP_BIN="$SCRIPT_DIR/../bin/pp"
+
+[ -f "$PP_BIN" ] || { echo "Cannot find bin/pp at $PP_BIN" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+TMPDIRS=()
+cleanup_tmpdirs() {
+    local tmp
+    for tmp in "${TMPDIRS[@]}"; do
+        rm -rf "$tmp"
+    done
+}
+trap cleanup_tmpdirs EXIT
+
+# --- helpers --------------------------------------------------------------
+
+# Build a tmp $PP_CONFIG_DIR with one or more registered projects.
+# Args: name1 name2 name3 ...
+make_registry() {
+    local tmp
+    tmp=$(mktemp -d)
+    TMPDIRS+=( "$tmp" )
+    mkdir -p "$tmp/projects"
+    local name
+    for name in "$@"; do
+        mkdir -p "$tmp/repo-$name/site---site/web-pages"
+        {
+            printf 'NAME="%s"\n' "$name"
+            printf 'REPO="%s/repo-%s"\n' "$tmp" "$name"
+            printf 'SITE_DIR="site---site"\n'
+            printf 'PROFILE="testprof"\n'
+        } > "$tmp/projects/$name.conf"
+    done
+    printf '%s\n' "$tmp"
+}
+
+assert_pass() {
+    local label="$1"
+    PASS=$((PASS + 1))
+    printf '  OK   %s\n' "$label"
+}
+
+assert_fail() {
+    local label="$1" detail="${2:-}"
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=( "$label" )
+    printf '  FAIL %s\n' "$label" >&2
+    [ -n "$detail" ] && printf '       %s\n' "$detail" >&2 || true
+}
+
+assert_contains() {
+    local label="$1" expected="$2" haystack="$3"
+    if [[ "$haystack" == *"$expected"* ]]; then
+        assert_pass "$label"
+    else
+        assert_fail "$label" "expected substring '$expected' in: $haystack"
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" forbidden="$2" haystack="$3"
+    if [[ "$haystack" != *"$forbidden"* ]]; then
+        assert_pass "$label"
+    else
+        assert_fail "$label" "forbidden substring '$forbidden' in: $haystack"
+    fi
+}
+
+# --- Section 1: project name resolution ----------------------------------
+
+echo "Section 1 — project name resolution"
+echo
+
+reg=$(make_registry alpha beta contoso-dev contoso-client)
+
+# Exact match
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show alpha 2>&1 || true)
+assert_contains "exact match: 'alpha' resolves to alpha" "alpha" "$out"
+
+# Unique prefix
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show be 2>&1 || true)
+assert_contains "unique prefix: 'be' resolves to beta" "beta" "$out"
+
+# Ambiguous prefix should fail with a clear error
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show contoso 2>&1 || true)
+assert_contains "ambiguous prefix produces error" "Ambiguous" "$out"
+assert_contains "ambiguous prefix lists candidates: contoso-dev" "contoso-dev" "$out"
+assert_contains "ambiguous prefix lists candidates: contoso-client" "contoso-client" "$out"
+
+# No match
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show nomatch 2>&1 || true)
+assert_contains "no-match produces 'Unknown project' error" "Unknown project" "$out"
+
+# Alias resolution
+echo "petro=contoso-dev" > "$reg/aliases"
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show petro 2>&1 || true)
+assert_contains "alias resolution: 'petro' resolves to contoso-dev" "contoso-dev" "$out"
+
+# Alias takes precedence over exact match? No — exact match is checked
+# first, then alias, then prefix. So if a project named "petro" existed,
+# the alias would NOT shadow it. Verify:
+mkdir -p "$reg/projects"
+{
+    printf 'NAME="petro"\n'
+    printf 'REPO="/tmp/x"\n'
+    printf 'SITE_DIR="s"\n'
+    printf 'PROFILE="p"\n'
+} > "$reg/projects/petro.conf"
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show petro 2>&1 || true)
+assert_contains "exact match wins over alias: 'petro' shows petro project" "Repo:           /tmp/x" "$out"
+
+# --- Section 2: cmd_show ---------------------------------------------------
+
+echo
+echo "Section 2 — cmd_show"
+echo
+
+reg=$(make_registry alpha)
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show alpha 2>&1 || true)
+assert_contains "show outputs project name" "alpha" "$out"
+assert_contains "show outputs Repo:" "Repo:" "$out"
+assert_contains "show outputs Site dir:" "Site dir:" "$out"
+assert_contains "show outputs PAC profile:" "PAC profile:" "$out"
+assert_contains "show outputs Config file:" "Config file:" "$out"
+
+# Show against non-existent project
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" show ghost 2>&1 || true)
+assert_contains "show against ghost: error" "Unknown project" "$out"
+
+# --- Section 3: cmd_list --------------------------------------------------
+
+echo
+echo "Section 3 — cmd_list"
+echo
+
+# Empty registry
+empty=$(mktemp -d); TMPDIRS+=( "$empty" )
+mkdir -p "$empty/projects"
+out=$(PP_CONFIG_DIR="$empty" "$PP_BIN" list 2>&1 || true)
+assert_contains "empty registry: friendly message" "No projects" "$out"
+
+# Populated registry
+reg=$(make_registry alpha beta gamma)
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" list 2>&1 || true)
+assert_contains "list shows alpha" "alpha" "$out"
+assert_contains "list shows beta" "beta" "$out"
+assert_contains "list shows gamma" "gamma" "$out"
+assert_contains "list has PROJECT header" "PROJECT" "$out"
+
+# --- Section 4: cmd_alias_add / cmd_alias_list ----------------------------
+
+echo
+echo "Section 4 — alias add/list"
+echo
+
+reg=$(make_registry alpha beta)
+
+# Valid alias
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" alias add a alpha 2>&1 || true)
+assert_contains "valid alias add succeeds" "Alias added" "$out"
+[ -f "$reg/aliases" ] && grep -q "^a=alpha$" "$reg/aliases" && assert_pass "alias written to file" \
+    || assert_fail "alias written to file"
+
+# Alias to non-existent target → die
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" alias add ghost ghostproject 2>&1 || true)
+assert_contains "alias to ghost target: rejected" "Unknown target" "$out"
+grep -q "^ghost=" "$reg/aliases" 2>/dev/null \
+    && assert_fail "ghost alias should NOT be written" \
+    || assert_pass "ghost alias not written (atomic reject)"
+
+# Invalid alias name → die
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" alias add 'ev;il' alpha 2>&1 || true)
+assert_contains "shell-metachar alias name rejected" "must match" "$out"
+
+# alias list — output is space-separated `<alias>  <target>`
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" alias list 2>&1 || true)
+assert_contains "alias list shows alias 'a'" "a" "$out"
+assert_contains "alias list shows target 'alpha'" "alpha" "$out"
+
+# Duplicate alias replaces (current behavior)
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" alias add a beta 2>&1 || true)
+assert_contains "duplicate alias replaces target" "Alias added" "$out"
+target_after=$(grep '^a=' "$reg/aliases" | cut -d= -f2)
+[ "$target_after" = "beta" ] && assert_pass "duplicate alias overwrites old target" \
+    || assert_fail "duplicate alias overwrite" "got '$target_after', expected 'beta'"
+
+# Alias file contains exactly one 'a=' entry
+count=$(grep -c '^a=' "$reg/aliases" || echo 0)
+[ "$count" = "1" ] && assert_pass "no duplicate alias rows" \
+    || assert_fail "no duplicate alias rows" "got $count rows"
+
+# --- Section 5: cmd_project_remove (atomicity) ----------------------------
+
+echo
+echo "Section 5 — cmd_project_remove"
+echo
+
+reg=$(make_registry alpha beta gamma)
+echo "a=alpha" > "$reg/aliases"
+echo "g=gamma" >> "$reg/aliases"
+echo "alpha" > "$reg/active"
+
+# Remove alpha — should delete conf AND alias AND clear active
+out=$(printf 'y\n' | PP_CONFIG_DIR="$reg" "$PP_BIN" project remove alpha 2>&1 || true)
+assert_contains "remove succeeds" "Removed alpha" "$out"
+[ ! -f "$reg/projects/alpha.conf" ] && assert_pass "alpha conf file removed" \
+    || assert_fail "alpha conf file still exists"
+grep -q "^a=alpha$" "$reg/aliases" 2>/dev/null \
+    && assert_fail "alias row still references removed alpha" \
+    || assert_pass "alias row removed"
+[ ! -f "$reg/active" ] && assert_pass "active file cleared" \
+    || assert_fail "active file not cleared" "contents: $(cat "$reg/active")"
+
+# Other aliases untouched
+grep -q "^g=gamma$" "$reg/aliases" \
+    && assert_pass "unrelated alias preserved" \
+    || assert_fail "unrelated alias g=gamma was wiped"
+
+# Remove non-existent project → die
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" project remove ghost 2>&1 || true)
+assert_contains "remove ghost: rejected" "Unknown project" "$out"
+
+# --- Section 6: cmd_switch / cmd_status -----------------------------------
+
+echo
+echo "Section 6 — switch / status"
+echo
+
+reg=$(make_registry alpha beta)
+
+# Status with no active project
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" status 2>&1 || true)
+assert_contains "status with no active: friendly message" "No active project" "$out"
+
+# Switch sets active
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" switch alpha 2>&1 || true)
+[ -f "$reg/active" ] && [ "$(cat "$reg/active")" = "alpha" ] \
+    && assert_pass "switch wrote active=alpha" \
+    || assert_fail "switch did not write active correctly" "active='$(cat "$reg/active" 2>/dev/null)'"
+
+# Status with active set
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" status 2>&1 || true)
+assert_contains "status with active: shows project name" "alpha" "$out"
+assert_not_contains "status doesn't say 'no active'" "No active project" "$out"
+
+# Switch to other project, status reflects new active
+PP_CONFIG_DIR="$reg" "$PP_BIN" switch beta >/dev/null 2>&1 || true
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" status 2>&1 || true)
+assert_contains "status reflects switched-to beta" "beta" "$out"
+
+# --- Section 7: cmd_journal init -----------------------------------------
+
+echo
+echo "Section 7 — cmd_journal init"
+echo
+
+reg=$(make_registry alpha)
+project_repo="$reg/repo-alpha"
+
+# init creates JOURNAL.md
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" journal alpha init 2>&1 || true)
+[ -f "$project_repo/JOURNAL.md" ] && assert_pass "journal init creates JOURNAL.md" \
+    || assert_fail "JOURNAL.md not created" "output: $out"
+
+# Template includes the project name
+content=$(cat "$project_repo/JOURNAL.md" 2>/dev/null || echo "")
+assert_contains "JOURNAL.md includes project name" "alpha" "$content"
+assert_contains "JOURNAL.md has Project Context section" "Project Context" "$content"
+
+# Idempotent: second init does NOT overwrite
+echo "MANUAL EDIT" >> "$project_repo/JOURNAL.md"
+PP_CONFIG_DIR="$reg" "$PP_BIN" journal alpha init >/dev/null 2>&1 || true
+content=$(cat "$project_repo/JOURNAL.md")
+assert_contains "init is idempotent (preserves manual edits)" "MANUAL EDIT" "$content"
+
+# --- Section 8: cmd_generate_page happy path ------------------------------
+
+echo
+echo "Section 8 — cmd_generate_page happy path"
+echo
+
+reg=$(make_registry alpha)
+project_repo="$reg/repo-alpha"
+site_dir="$project_repo/site---site"
+
+# Generate a page with a valid name
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" generate-page alpha "My New Page" 2>&1 || true)
+page_dir="$site_dir/web-pages/my-new-page"
+[ -d "$page_dir" ] && assert_pass "page dir created" \
+    || assert_fail "page dir not created" "output: $out"
+[ -f "$page_dir/My New Page.webpage.yml" ] && assert_pass "base YAML created" \
+    || assert_fail "base YAML missing"
+[ -f "$page_dir/My New Page.webpage.copy.html" ] && assert_pass "base HTML created" \
+    || assert_fail "base HTML missing"
+[ -d "$page_dir/content-pages" ] && assert_pass "content-pages dir created" \
+    || assert_fail "content-pages dir missing"
+
+# Existing page → die
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" generate-page alpha "My New Page" 2>&1 || true)
+assert_contains "duplicate generate-page rejected" "already exists" "$out"
+
+# --- Section 9: cmd_sync_pages -------------------------------------------
+
+echo
+echo "Section 9 — cmd_sync_pages"
+echo
+
+reg=$(make_registry alpha)
+project_repo="$reg/repo-alpha"
+page_dir="$project_repo/site---site/web-pages/test-page"
+mkdir -p "$page_dir/content-pages/en-US"
+echo "BASE CONTENT" > "$page_dir/test-page.webpage.copy.html"
+echo "OLD LOCALIZED" > "$page_dir/content-pages/en-US/test-page.en-US.webpage.copy.html"
+
+# base-to-localized: base content should overwrite localized
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" sync-pages alpha base-to-localized 2>&1 || true)
+loc=$(cat "$page_dir/content-pages/en-US/test-page.en-US.webpage.copy.html" 2>/dev/null || echo "")
+[ "$loc" = "BASE CONTENT" ] && assert_pass "base-to-localized copied content" \
+    || assert_fail "base-to-localized failed" "loc='$loc'"
+
+# Reset and test the other direction
+echo "NEW BASE" > "$page_dir/test-page.webpage.copy.html"
+echo "LOCALIZED CONTENT" > "$page_dir/content-pages/en-US/test-page.en-US.webpage.copy.html"
+
+# localized-to-base: localized should overwrite base
+out=$(PP_CONFIG_DIR="$reg" "$PP_BIN" sync-pages alpha localized-to-base 2>&1 || true)
+base=$(cat "$page_dir/test-page.webpage.copy.html" 2>/dev/null || echo "")
+[ "$base" = "LOCALIZED CONTENT" ] && assert_pass "localized-to-base copied content" \
+    || assert_fail "localized-to-base failed" "base='$base'"
+
+# Invalid direction
+out=$(printf 'invalid\n' | PP_CONFIG_DIR="$reg" "$PP_BIN" sync-pages alpha 2>&1 || true)
+assert_contains "invalid sync-pages direction rejected" "Invalid choice" "$out"
+
+# --- Section 10: cmd_help ------------------------------------------------
+
+echo
+echo "Section 10 — cmd_help"
+echo
+
+out=$("$PP_BIN" help 2>&1)
+status=$?
+[ "$status" = "0" ] && assert_pass "help exits 0" \
+    || assert_fail "help non-zero exit" "status=$status"
+assert_contains "help lists 'down'" "pp down" "$out"
+assert_contains "help lists 'up'" "pp up" "$out"
+assert_contains "help lists 'doctor'" "pp doctor" "$out"
+assert_contains "help lists 'audit'" "pp audit" "$out"
+assert_contains "help lists 'setup'" "setup" "$out"
+assert_contains "help lists 'journal'" "journal" "$out"
+
+# --- Summary ---------------------------------------------------------------
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+    printf '%d/%d passed\n' "$PASS" "$((PASS + FAIL))"
+    exit 0
+else
+    printf '%d/%d passed; failures: %s\n' "$PASS" "$((PASS + FAIL))" "${FAIL_NAMES[*]}" >&2
+    exit 1
+fi

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.7.4"
+        "version": "2.7.5"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.0.3",
+        "pp-sync": "2.0.4",
         "pp-permissions-audit": "1.5.2"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.7.4"
+        "pp_permissions_audit_ci_ref": "v2.7.5"
     }
 }


### PR DESCRIPTION
Deeper test coverage. Adds `test_command_flows.sh` covering pp subcommand flows the existing suites don't reach (project resolution ambiguity, alias atomicity, project-remove cleanup, switch/status state, journal init, generate-page happy path, sync-pages both directions, help output).

Writing the tests surfaced **2 more real bugs**, both fixed in this same release.

## New suite: 59 cases, 10 sections

| § | Cases | What it pins down |
|---|---|---|
| 1 | 8 | Project name resolution: exact, prefix, ambiguous (asserts both candidates listed), no-match, alias, alias-vs-exact precedence |
| 2 | 6 | cmd_show: all field labels, ghost-project error |
| 3 | 5 | cmd_list: empty + populated registry |
| 4 | 9 | Alias add/list: atomic ghost-target reject, metachar reject, duplicate replacement, no-duplicate-rows |
| 5 | 6 | cmd_project_remove: atomic deletion of conf + alias rows + active file |
| 6 | 5 | switch/status state consistency |
| 7 | 4 | journal init idempotency |
| 8 | 5 | generate-page happy path file structure |
| 9 | 3 | sync-pages both directions + invalid direction reject |
| 10 | 7 | cmd_help exits 0 + lists all subcommands |

## New bugs surfaced + fixed (pp-sync v2.0.4)

**1. `cmd_generate_page` silent abort under strict mode** — `find $SITE_DIR/page-templates -name "*.pagetemplate.yml" \| head -1 \| sed ...` tripped pipefail when `page-templates/` didn't exist (a fresh portal source). The function said "Generating page" but produced zero files because the assignment aborted before `mkdir -p`. Added `\|\| true`.

**2. `cmd_sync_pages` couldn't find localized files in actual Power Pages layout** — glob `"$cp_dir"/*"$suffix"` only matched files DIRECTLY in `content-pages/`, never recursing into the `<lang>/` subdirs where Power Pages stores them. Every `pp sync-pages` on a real portal reported "Copied: 0" regardless of state. Replaced glob with `find -type f -name "*$suffix"` (mirrors the rglob fix audit.py just got).

## Test count: 127 (was 60)

| Suite | Tests |
|---|---|
| audit.py | 8 |
| test_load_project.sh | 15 |
| test_register_atomic.sh | 6 |
| test_journal_url_validation.sh | 16 |
| test_subcommand_safety.sh | 23 |
| **test_command_flows.sh (NEW)** | **59** |

## Versions

| Component | Before | After |
|---|---|---|
| Marketplace | 2.7.4 | **2.7.5** |
| pp-sync | 2.0.3 | **2.0.4** |