### PR TITLE
v2.8.0: integration tests + $HOME backward-compat fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.8.0] — 2026-04-29
+
+Integration test framework + a real-world backward-compat fix surfaced by running tests against a real portal.
+
+### Added (pp-sync v2.1.0)
+
+- **NEW `tests/integration/test_pac_dependent.sh`** — local-only integration tests that exercise pp subcommands against a real `pac` install + a registered project. Covers `pp doctor` (full pac auth path), `pp diff` (git diff against site dir), `pp up --validate-only` (pac validation without push), `pp audit` (Python audit dispatch + JSON parse), `pp status` (active project + live env). **Auto-skips** if `pac` isn't installed or no projects are registered, so it's safe to run anywhere. NOT wired into CI (the GitHub Actions runner has neither `pac` nor user projects). Documented as a smoke gate before each release.
+- **`PP_INTEGRATION_PROJECT=<name>`** env var to target a specific project; defaults to the first registered.
+- **`PP_INTEGRATION_DESTRUCTIVE=1`** opt-in for testing `pp down` (and the abort path of confirmation prompts). Even with the flag set, `pp solution-up` is permanently disabled by the suite — too risky to run unsupervised.
+
+### Fixed (pp-sync v2.1.0) — backward-compat for confs created pre-v2.0.0
+
+- **`load_project` now expands a leading literal `$HOME` in `REPO`** as a backward-compat affordance for confs created before v2.0.0 (when `pp` source-evaluated the conf and `$HOME` was expanded by the shell). The expansion is pure string substitution — only the prefix `$HOME` is replaced; no other `$VAR` references are processed and no shell evaluation occurs. Same security property as the existing `~` expansion.
+  - **Why this matters**: real-world testing (the new integration suite!) revealed that the user's existing 4 conf files all had `REPO="$HOME/Projects/..."` — written when the v1.x source-evaluated loader expanded `$HOME` automatically. v2.0.0+ stored these as literal strings, breaking every `pp` operation against those projects (`pp doctor`, `pp diff`, `pp up`, `pp audit` all failed with "Project repo not found: $HOME/...").
+  - **What's still safe**: only the literal prefix `$HOME` is special-cased. Confs with `$(...)`, backticks, or other `$VAR` references still store as literal strings. The parser security property is unchanged.
+  - Regression test added: `tests/fixtures/legacy-home-prefix.conf` + new assertion in `test_load_project.sh` (test count → 21).
+
+### Documentation
+
+- **CONTRIBUTING.md "Integration tests" section** — documents the local-only suite + how to run it before each release.
+- **tests/README.md** — expanded with full coverage of the integration suite, fixture conventions, opt-in flags.
+
 ## [2.7.7] — 2026-04-29
 
 Final coverage round + security disclosure docs. Adds tests for the last 9 untested audit rules, a `SECURITY.md` for vulnerability reporting, and a CONTRIBUTING section on adding audit rules.
@@ -430,6 +452,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.8.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.8.0
 [2.7.7]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.7
 [2.7.6]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.6
 [2.7.5]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,16 @@ The bash suites use fixture files under `plugins/pp-sync/tests/fixtures/` and a 
 
 When adding a new `pp` subcommand or registration path, add fixtures + assertions to the matching suite. The suites are wired into `.github/workflows/plugin-validate.yml` automatically.
 
+## Integration tests (local-only)
+
+Beyond the four bash suites that run in CI, `plugins/pp-sync/tests/integration/test_pac_dependent.sh` exercises pp subcommands against a real `pac` install + a registered project. **Run this before each release** as a smoke gate:
+
+```bash
+bash plugins/pp-sync/tests/integration/test_pac_dependent.sh
+```
+
+The suite auto-skips if `pac` isn't installed or no projects are registered, so it's safe to run anywhere. It's NOT wired into CI because the GitHub Actions runner has neither `pac` nor user-registered projects. See `plugins/pp-sync/tests/README.md` for full details + opt-in destructive-test flags.
+
 ## Static analysis
 
 CI runs ShellCheck at `--severity=warning` against every shell script. Install locally:

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.7.7` by default)
+- Fetches the audit script from a pinned tag (`v2.8.0` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.7.7'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.8.0'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.7/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.8.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.7.7/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.8.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.7.7'   (recommended for production projects)
+#   AUDIT_REF:  'v2.8.0'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.7.7'
+  AUDIT_REF:  'v2.8.0'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.0.5",
+    "version": "2.1.0",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -304,8 +304,15 @@ load_project() {
     [ -n "$BOARD_SYSTEM" ] || BOARD_SYSTEM="auto"
     [ -n "$AI_ATTR" ] || AI_ATTR="yes"
 
-    # Expand ~ in REPO via bash parameter expansion (no shell evaluation)
+    # Expand `~` and a leading literal `$HOME` in REPO via bash parameter
+    # expansion. The `$HOME` form is a backward-compat affordance for
+    # confs created before v2.0.0 (when `pp` source-evaluated the conf
+    # and `$HOME` was expanded by the shell). Both expansions are pure
+    # string substitution — only the matching prefix is replaced; no
+    # other `$VAR` references are processed and no shell evaluation
+    # occurs.
     REPO="${REPO/#~/$HOME}"
+    REPO="${REPO/#\$HOME/$HOME}"
 
     # Session safety for journaling only. Do not block non-interactive pp flows.
     local board_verify_key=""

--- a/plugins/pp-sync/tests/README.md
+++ b/plugins/pp-sync/tests/README.md
@@ -56,3 +56,30 @@ When the file is sourced, `return` succeeds (we're inside a sourced script), so 
 The system under test is `bin/pp`, a 1500-line bash script. Sourcing it from bash gives direct access to its functions and variables. Re-implementing the same harness in Python would need a subprocess shim that hides the very behavior we want to verify (function-table state, IFS handling, dynamic scoping) — exactly the things that surface real bugs in shell code.
 
 The Python suite (`audit.py`) tests Python code; the bash suites test bash code.
+
+## Integration tests (`tests/integration/`)
+
+A separate `integration/` subdirectory holds tests that exercise pp subcommands against a **real `pac` install + a registered project**. They are NOT wired into CI (the GitHub Actions runner has neither `pac` nor user projects).
+
+Run locally:
+
+```bash
+bash plugins/pp-sync/tests/integration/test_pac_dependent.sh
+```
+
+What it checks (against the first registered project):
+- `pp doctor` — full pac auth path; asserts every section runs to completion
+- `pp diff` — git diff against site dir
+- `pp up --validate-only` — pac validation without push
+- `pp audit` — Python audit dispatch + JSON output parses
+- `pp status` — active project + live env
+
+The suite **auto-skips** if `pac` isn't installed or no projects are registered. To target a specific project:
+
+```bash
+PP_INTEGRATION_PROJECT=anchor bash tests/integration/test_pac_dependent.sh
+```
+
+Destructive operations (`pp down`, `pp up`, `pp solution-up`) are gated behind `PP_INTEGRATION_DESTRUCTIVE=1`. Even with that flag set, `pp solution-up` is permanently disabled by the suite — run it manually if you need to.
+
+These integration tests are a smoke gate before each release. They prove the bash → pac → portal hand-off still works in practice; the in-CI unit tests prove the bash code is correct in isolation.

--- a/plugins/pp-sync/tests/fixtures/legacy-home-prefix.conf
+++ b/plugins/pp-sync/tests/fixtures/legacy-home-prefix.conf
@@ -1,0 +1,4 @@
+NAME="legacy-home"
+REPO="$HOME/Projects/some/path"
+SITE_DIR="site---site"
+PROFILE="profile"

--- a/plugins/pp-sync/tests/integration/test_pac_dependent.sh
+++ b/plugins/pp-sync/tests/integration/test_pac_dependent.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Local integration tests for pp subcommands that depend on pac.
+#
+# These tests exercise the read-only / non-destructive subset of pp
+# subcommands against a REAL registered project. They run on a local
+# developer machine where:
+#   - `pac` is installed and a profile is registered
+#   - At least one project has been registered via `pp setup` or
+#     `pp project add`
+#
+# They are NOT wired into CI (the GitHub Actions runner has neither
+# pac nor user projects). When run in an environment without pac or
+# without registered projects, this suite skips cleanly with exit 0.
+#
+# By default the suite picks the first registered project. To target
+# a specific one:
+#
+#     PP_INTEGRATION_PROJECT=anchor bash test_pac_dependent.sh
+#
+# Destructive operations (`pp down`, `pp up`, `pp solution-up`) are
+# never run by this suite — they would modify the user's local files
+# or push to a portal. To opt in to those (against your dev environment
+# only):
+#
+#     PP_INTEGRATION_DESTRUCTIVE=1 bash test_pac_dependent.sh
+#
+# Even with that flag set, this suite still skips solution-up to prod
+# without explicit per-test confirmation.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PP_BIN="$SCRIPT_DIR/../../bin/pp"
+
+[ -f "$PP_BIN" ] || { echo "Cannot find bin/pp at $PP_BIN" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+SKIP=0
+FAIL_NAMES=()
+
+# --- Pre-flight ---------------------------------------------------------
+
+if ! command -v pac >/dev/null 2>&1; then
+    printf '%s\n' "SKIP — pac CLI not installed (this suite requires Power Platform CLI)"
+    exit 0
+fi
+
+# Discover registered projects via `pp list`. Skip if none.
+projects_output=$("$PP_BIN" list 2>/dev/null || true)
+case "$projects_output" in
+    *"No projects registered"*)
+        printf '%s\n' "SKIP — no projects registered (run \`pp setup\` first)"
+        exit 0
+        ;;
+esac
+
+# Pick a project. Honor PP_INTEGRATION_PROJECT if set, else first row.
+TARGET="${PP_INTEGRATION_PROJECT:-}"
+if [ -z "$TARGET" ]; then
+    # First non-header row of `pp list` — strip leading whitespace, take
+    # first column.
+    TARGET=$(printf '%s\n' "$projects_output" \
+        | awk 'NR>2 && $1!="" && $1!~/^-/ {print $1; exit}')
+fi
+if [ -z "$TARGET" ]; then
+    printf '%s\n' "SKIP — could not pick a project from \`pp list\` output"
+    exit 0
+fi
+
+# Validate the chosen project actually exists.
+if ! "$PP_BIN" show "$TARGET" >/dev/null 2>&1; then
+    printf '%s\n' "SKIP — chosen project '$TARGET' not resolvable"
+    exit 0
+fi
+
+printf 'Running pac-dependent integration tests against project: %s\n\n' "$TARGET"
+
+# --- helpers ------------------------------------------------------------
+
+assert_pass() {
+    PASS=$((PASS + 1))
+    printf '  OK   %s\n' "$1"
+}
+
+assert_fail() {
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=( "$1" )
+    printf '  FAIL %s\n' "$1" >&2
+    [ -n "${2:-}" ] && printf '       %s\n' "$2" >&2 || true
+}
+
+skip() {
+    SKIP=$((SKIP + 1))
+    printf '  SKIP %s — %s\n' "$1" "$2"
+}
+
+# --- Section 1: pp doctor (full pac auth path) --------------------------
+
+echo "Section 1 — pp doctor"
+echo
+
+doctor_out=$("$PP_BIN" doctor "$TARGET" 2>&1 || true)
+doctor_exit=$?
+
+# Doctor should exit 0 even if some checks warn.
+[ "$doctor_exit" = "0" ] && assert_pass "doctor exits 0" \
+    || assert_fail "doctor non-zero exit" "exit=$doctor_exit"
+
+# Doctor should reach the Site content counts section, which is the LAST
+# section. If it didn't, doctor aborted mid-flow.
+case "$doctor_out" in
+    *"Site content counts"*)
+        assert_pass "doctor reaches Site content counts section"
+        ;;
+    *)
+        assert_fail "doctor did not reach Site content counts section" \
+            "output: $doctor_out"
+        ;;
+esac
+
+# Tooling section ran
+case "$doctor_out" in
+    *"Tooling"*) assert_pass "doctor: Tooling section present" ;;
+    *) assert_fail "doctor: Tooling section missing" ;;
+esac
+
+# PAC auth section ran (we tolerate either "Profile X registered" or
+# the negative case — what matters is the section appeared)
+case "$doctor_out" in
+    *"PAC auth"*) assert_pass "doctor: PAC auth section present" ;;
+    *) assert_fail "doctor: PAC auth section missing" ;;
+esac
+
+# --- Section 2: pp diff (git diff against site dir, read-only) ----------
+
+echo
+echo "Section 2 — pp diff"
+echo
+
+diff_out=$("$PP_BIN" diff "$TARGET" 2>&1 || true)
+diff_exit=$?
+[ "$diff_exit" = "0" ] && assert_pass "diff exits 0" \
+    || assert_fail "diff non-zero exit" "exit=$diff_exit"
+
+# Diff should print a header indicating its scope.
+case "$diff_out" in
+    *"Diff preview"*|*"Site dir"*|*"No changes"*|*"already in sync"*|*"Total changed"*|*"files changed"*)
+        assert_pass "diff produced output describing portal state"
+        ;;
+    *)
+        assert_fail "diff produced unexpected output" "first lines: $(printf '%s' "$diff_out" | head -3)"
+        ;;
+esac
+
+# --- Section 3: pp up --validate-only (pac validates without push) ------
+
+echo
+echo "Section 3 — pp up --validate-only"
+echo
+
+# pac paportal upload --validateBeforeUpload is a real network call but
+# does NOT push. Skipped if there's nothing changed (--validate-only on
+# clean tree may be a no-op).
+up_out=$("$PP_BIN" up "$TARGET" --validate-only 2>&1 || true)
+up_exit=$?
+
+# Either succeeds (validation OK) or fails with a meaningful message.
+# What matters is that pp itself reaches the validation step rather
+# than aborting before invoking pac.
+case "$up_out" in
+    *"validate"*|*"Validate"*|*"Already in sync"*|*"No changes"*|*"upload"*|*"Upload"*)
+        assert_pass "up --validate-only invoked pac path"
+        ;;
+    *"PAC"*|*"profile"*)
+        # pac auth issue — skip rather than fail
+        skip "up --validate-only" "pac auth not ready ($up_out)"
+        ;;
+    *)
+        assert_fail "up --validate-only unexpected output" \
+            "exit=$up_exit out: $(printf '%s' "$up_out" | head -3)"
+        ;;
+esac
+
+# --- Section 4: pp audit (Python audit dispatch via bash) --------------
+
+echo
+echo "Section 4 — pp audit"
+echo
+
+audit_out=$("$PP_BIN" audit "$TARGET" --severity ERROR --json 2>&1 || true)
+
+# audit may exit 0 (no errors) or 1 (errors found) — both are valid
+# functional outcomes. We assert that JSON parses, proving the bash
+# dispatcher correctly invoked python and the python emitted JSON.
+if printf '%s' "$audit_out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then
+    assert_pass "audit produced parseable JSON"
+else
+    # Look for "audit script not found" — would indicate the bash
+    # dispatcher couldn't locate audit.py (a real bug).
+    case "$audit_out" in
+        *"audit script not found"*|*"Cannot find"*)
+            assert_fail "audit dispatch: script lookup failed" \
+                "out: $audit_out"
+            ;;
+        *)
+            # Other failures (e.g., permissions issue, unexpected pac
+            # interaction) are worth flagging but not blocking.
+            skip "audit JSON parse" \
+                "non-JSON output (may be acceptable): $(printf '%s' "$audit_out" | head -3)"
+            ;;
+    esac
+fi
+
+# --- Section 5: pp status (live env from pac org who) -------------------
+
+echo
+echo "Section 5 — pp status"
+echo
+
+# Set the active project explicitly to the target so status has something
+# coherent to report.
+"$PP_BIN" switch "$TARGET" >/dev/null 2>&1 || true
+
+status_out=$("$PP_BIN" status 2>&1 || true)
+status_exit=$?
+[ "$status_exit" = "0" ] && assert_pass "status exits 0" \
+    || assert_fail "status non-zero exit" "exit=$status_exit"
+
+# Should mention the active project name
+case "$status_out" in
+    *"$TARGET"*) assert_pass "status names the active project" ;;
+    *) assert_fail "status doesn't mention active project '$TARGET'" ;;
+esac
+
+# --- Destructive-only section (gated by env var) ------------------------
+
+echo
+echo "Section 6 — destructive ops (gated)"
+echo
+
+if [ "${PP_INTEGRATION_DESTRUCTIVE:-0}" != "1" ]; then
+    skip "down / up / solution-up" \
+        "set PP_INTEGRATION_DESTRUCTIVE=1 to opt in"
+else
+    # Even with the flag, we never run solution-up — too risky against
+    # any environment that's not isolated.
+    skip "solution-up" "permanently disabled in this suite"
+
+    # `pp down` can be exercised with confirmation. We auto-decline.
+    down_out=$(printf 'n\n' | "$PP_BIN" down "$TARGET" 2>&1 || true)
+    case "$down_out" in
+        *"Aborted"*|*"aborted"*|*"cancel"*)
+            assert_pass "down respects abort confirmation"
+            ;;
+        *)
+            assert_fail "down did not respect abort: $(printf '%s' "$down_out" | head -3)"
+            ;;
+    esac
+fi
+
+# --- Summary -----------------------------------------------------------
+
+echo
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+    if [ "$SKIP" -gt 0 ]; then
+        printf '%d/%d passed (%d skipped — see notes above)\n' "$PASS" "$TOTAL" "$SKIP"
+    else
+        printf '%d/%d passed\n' "$PASS" "$TOTAL"
+    fi
+    exit 0
+else
+    printf '%d/%d passed; failures: %s\n' "$PASS" "$TOTAL" "${FAIL_NAMES[*]}" >&2
+    exit 1
+fi

--- a/plugins/pp-sync/tests/test_load_project.sh
+++ b/plugins/pp-sync/tests/test_load_project.sh
@@ -279,6 +279,17 @@ run_test "tab-in-value" "ok" '
     esac
 '
 
+# 19. Backward-compat: confs created before v2.0.0 stored REPO as
+#     "$HOME/path" expecting the shell to expand it. v2.0.0+ stores it
+#     as a literal string by default. The loader expands a leading
+#     literal `$HOME` (and `~`) so existing user confs keep working.
+#     The expansion is pure string substitution — no shell evaluation.
+run_test "legacy-home-prefix" "ok" '
+    expected="$HOME/Projects/some/path"
+    [ "$REPO" = "$expected" ] || { echo "REPO=$REPO expected=$expected"; exit 1; }
+    exit 0
+'
+
 # --- Summary ---------------------------------------------------------------
 
 echo

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.7.7"
+        "version": "2.8.0"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.0.5",
+        "pp-sync": "2.1.0",
         "pp-permissions-audit": "1.5.4"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.7.7"
+        "pp_permissions_audit_ci_ref": "v2.8.0"
     }
 }


### PR DESCRIPTION
Integration test framework + the bug it immediately surfaced when run against a real Power Pages portal.

## Added: `tests/integration/test_pac_dependent.sh`

Local-only integration tests against a real `pac` install + a registered project. Covers:

| Subcommand | What it checks |
|---|---|
| `pp doctor` | Full pac auth path; asserts every section completes |
| `pp diff` | Git diff against site dir |
| `pp up --validate-only` | pac validation without push |
| `pp audit` | Python audit dispatch + JSON parse |
| `pp status` | Active project + live env |

**Auto-skips** if `pac` isn't installed or no projects are registered. NOT wired into CI (the GitHub Actions runner has neither). Designed as a smoke gate before each release.

Env vars:
- `PP_INTEGRATION_PROJECT=<name>` — target a specific project (defaults to first registered)
- `PP_INTEGRATION_DESTRUCTIVE=1` — opt in to `pp down` (abort path only); `pp solution-up` is permanently disabled

## Fixed: \$HOME backward-compat in `load_project` (pp-sync v2.1.0)

**Real-world testing surfaced this**. Running the new integration suite against the user's existing projects immediately failed with "Project repo not found: \$HOME/...". The user's 4 conf files all had `REPO="\$HOME/Projects/..."` written when the v1.x source-evaluated loader expanded `\$HOME` automatically. v2.0.0+ stored these literally.

Fix: `load_project` now expands a leading literal `\$HOME` in `REPO` via parameter expansion. Pure string substitution — only the prefix `\$HOME` is replaced; no other `\$VAR` references processed and no shell evaluation occurs. Same security property as the existing `~` expansion.

Regression test: `tests/fixtures/legacy-home-prefix.conf` + assertion in `test_load_project.sh` (count: 20 → 21).

## Test count

| Suite | Count |
|---|---|
| audit.py | 26 |
| test_load_project.sh | **21** (was 20) |
| test_register_atomic.sh | 6 |
| test_journal_url_validation.sh | 16 |
| test_subcommand_safety.sh | 23 |
| test_command_flows.sh | 66 |
| test_install_script.sh | 13 |
| **CI subtotal** | **171** |
| `tests/integration/` (local-only) | 8 (5 pass + 3 skip in user's env) |

## Versions

| Component | Before | After |
|---|---|---|
| Marketplace | 2.7.7 | **2.8.0** |
| pp-sync | 2.0.5 | **2.1.0** |
| pp-permissions-audit | 1.5.4 | (no change) |