### PR TITLE
v2.9.0: pac mock + 13 mocked CI tests (chunk 1 of pac-mocking)

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -173,6 +173,11 @@ jobs:
           bash plugins/pp-sync/tests/test_install_script.sh
           echo "OK    pp install.sh tests pass"
 
+      - name: Run pp pac-mocked tests
+        run: |
+          bash plugins/pp-sync/tests/test_pac_mocked.sh
+          echo "OK    pp pac-mocked tests pass"
+
       - name: Bash syntax check
         run: |
           fail=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.9.0] — 2026-04-29
+
+Pac-mocked CI integration tests. Closes the "pac happy paths only run locally" gap by introducing a shell-script mock of the Microsoft Power Platform CLI.
+
+### Added (pp-sync v2.2.0)
+
+- **`tests/mocks/pac`** — a 250-line shell-script mock of `pac`. Implements the subset `pp-sync` invokes (`auth list/select/create`, `org who`, `paportal list/download/upload`, `solution export/unpack/pack/import`, `--version`) with realistic stdout shapes that `pp` parses against. Backed by a state directory (`$PP_MOCK_PAC_STATE_DIR`) so multiple invocations within one test interact coherently.
+- **Failure injection via env vars** — `PP_MOCK_PAC_FAIL_AUTH_LIST=1` and `PP_MOCK_PAC_FAIL_ORG_WHO=1` force the mock to fail those specific commands, letting tests exercise pp's error-handling paths.
+- **`tests/test_pac_mocked.sh`** — 13 tests exercising the mocked path:
+  - `pp doctor` full pac auth path (registered profile, connected env URL, all sections complete)
+  - `pp doctor` against unregistered profile — surfaces the registration error
+  - `pp switch` writes active + invokes `pac auth select`
+  - `pp status` reports live env URL from `pac org who`
+  - `pp up --validate-only` invokes pac validate path
+  - `pp down` end-to-end with mocked `pac paportal download`
+  - `pp up` (full) with mocked `pac paportal upload`
+  - `pp solution-down` end-to-end with mocked solution export/unpack
+  - Failure injection: pac auth list failure surfaces correctly
+- **CI wired** — new "Run pp pac-mocked tests" step runs on every PR. Total CI test count: **184** (was 171). Local-only `tests/integration/test_pac_dependent.sh` still runs against real pac for smoke-gating before each release.
+- **`tests/mocks/README.md`** — documents what's mocked, the state-directory layout, failure-injection env vars, and what's NOT mocked (yet).
+
+### Why this matters
+
+Before this release, `pp doctor`, `pp down`, `pp up`, `pp solution-down/up`, and other pac-dependent operations had **zero CI coverage**. They could only be tested locally on a developer machine with a real Power Platform tenant. Any regression to those code paths would have been invisible to CI until a maintainer happened to run the local integration suite.
+
+The mock removes that gap. The mocked test suite runs in 1-2 seconds in CI, requires no external dependencies, and exercises the same `bin/pp` code paths as a real pac. Combined with the local integration tests (which still verify the bash → pac → portal hand-off works against real environments), pp now has a two-layer coverage strategy: **mock-driven unit-style tests in CI for every PR, plus real-environment smoke tests before each release**.
+
 ## [2.8.0] — 2026-04-29
 
 Integration test framework + a real-world backward-compat fix surfaced by running tests against a real portal.
@@ -452,6 +479,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.9.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.0
 [2.8.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.8.0
 [2.7.7]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.7
 [2.7.6]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.7.6

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.8.0` by default)
+- Fetches the audit script from a pinned tag (`v2.9.0` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.8.0'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.9.0'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.8.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.9.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.8.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.9.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.8.0'   (recommended for production projects)
+#   AUDIT_REF:  'v2.9.0'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.8.0'
+  AUDIT_REF:  'v2.9.0'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/tests/mocks/README.md
+++ b/plugins/pp-sync/tests/mocks/README.md
@@ -1,0 +1,70 @@
+# Mock pac CLI
+
+This directory contains a shell-script mock of the Microsoft Power Platform CLI (`pac`). It implements the subset of `pac` that `pp-sync` invokes, with realistic stdout shapes that `pp` parses against. State is held in a configurable directory so multiple invocations within a test interact coherently.
+
+## Why a mock at all
+
+`pp-sync` orchestrates `pac` for every sync, doctor, and solution operation. Real-world testing of those flows requires a Power Platform tenant + an authenticated PAC profile (see `tests/integration/test_pac_dependent.sh`). The mock lets the same flows be exercised in CI without any of that — deterministic, fast, no secrets needed.
+
+## What's mocked
+
+| `pac` subcommand | What the mock does |
+|---|---|
+| `pac auth list` | Prints registered profiles in the same tabular shape `pp` parses |
+| `pac auth select --name X` | Marks `X` as selected; fails if `X` not in the profiles file |
+| `pac auth create --name X --environment Y` | Registers `X` with URL `Y`, marks selected |
+| `pac org who` | Prints the selected profile's URL in the format `pp` parses |
+| `pac paportal list` | Prints two fake portals |
+| `pac paportal download --path P --webSiteId G` | Creates a minimal `<P>/sample-site---sample-site/` skeleton |
+| `pac paportal upload [--validateBeforeUpload]` | Echoes "Validation OK" or "Upload complete" |
+| `pac solution export --path X` | Writes a stub zip (just the ZIP magic bytes) |
+| `pac solution unpack --folder F` | Creates `F/Entities/` + `F/Other/Solution.xml` |
+| `pac solution pack --zipfile Z` | Writes a stub zip |
+| `pac solution import` | Echoes success |
+| `pac --version` | Prints a mock version string |
+
+## State directory
+
+State persists in `$PP_MOCK_PAC_STATE_DIR` (default: `$HOME/.pp-mock-pac`). Tests should set this to a per-test `mktemp -d` so registrations don't leak between cases:
+
+```bash
+state=$(mktemp -d)
+PATH="$mocks:$PATH" PP_MOCK_PAC_STATE_DIR="$state" pp doctor myproj
+rm -rf "$state"
+```
+
+State files:
+- `profiles` — one line per registered profile: `name=env_url`
+- `selected` — currently selected profile name
+
+To pre-populate a profile (skip the `auth create` step):
+
+```bash
+echo "myprof=https://acme-dev.crm.dynamics.com/" > "$state/profiles"
+echo "myprof" > "$state/selected"
+```
+
+## Failure injection
+
+Tests can force the mock to fail specific commands via env vars:
+
+| Env var | Causes |
+|---|---|
+| `PP_MOCK_PAC_FAIL_AUTH_LIST=1` | `pac auth list` exits 1 with "Error: failed to read profile list" |
+| `PP_MOCK_PAC_FAIL_ORG_WHO=1` | `pac org who` exits 1 with "No profile selected" |
+
+This lets tests verify `pp`'s error-handling paths without contriving real auth failures.
+
+## What's NOT mocked (yet)
+
+- `pac auth delete`
+- `pac auth update`
+- `pac paportal create`
+- `pac plugin*` subcommands
+- Real solution validation (the mock's `solution import` always succeeds)
+
+Add new subcommands to `pac` as new `cmd_<sub>_<action>()` functions and dispatch to them in `main()`.
+
+## Why this is a shell script and not a Python tool
+
+Same reason the test suites are bash: it runs on every machine that has bash, with no `pip install`. Tests that depend on the mock add no new dependencies to CI. The mock is ~250 lines — short enough to read end-to-end before trusting.

--- a/plugins/pp-sync/tests/mocks/pac
+++ b/plugins/pp-sync/tests/mocks/pac
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Mock for the Microsoft Power Platform CLI (`pac`).
+#
+# Implements the subset of pac that pp-sync invokes, with realistic
+# stdout shapes pp parses against. Backed by a state directory so
+# `auth select` / `org who` / `auth create` interact coherently across
+# multiple invocations within one test.
+#
+# Tests put this script's directory first in PATH so it shadows any
+# real `pac` install:
+#
+#   PATH="$SCRIPT_DIR/../tests/mocks:$PATH" pp doctor anchor
+#
+# State directory: $PP_MOCK_PAC_STATE_DIR (default: $HOME/.pp-mock-pac)
+# Files in state dir:
+#   profiles      — one line per registered profile: name=env_url
+#   selected      — currently selected profile name
+#
+# To inject a profile for a test:
+#   mkdir -p "$state/profiles" && echo "myprof=https://acme-dev.crm.dynamics.com/" >> "$state/profiles"
+
+set -uo pipefail
+
+STATE_DIR="${PP_MOCK_PAC_STATE_DIR:-$HOME/.pp-mock-pac}"
+mkdir -p "$STATE_DIR"
+PROFILES_FILE="$STATE_DIR/profiles"
+SELECTED_FILE="$STATE_DIR/selected"
+[ -f "$PROFILES_FILE" ] || : > "$PROFILES_FILE"
+
+# Test failure injection: when set, pac fails with a configurable error.
+# Tests use this to exercise pp's error-handling paths.
+#
+#   PP_MOCK_PAC_FAIL_AUTH_LIST=1 pp doctor anchor   → pac auth list fails
+#   PP_MOCK_PAC_FAIL_ORG_WHO=1                       → pac org who returns no URL
+
+# --- helpers -------------------------------------------------------------
+
+profile_url() {
+    # Look up env URL for a profile name. Echo URL on stdout if found,
+    # exit 1 if not.
+    local name="$1" line
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            "$name="*) printf '%s\n' "${line#*=}"; return 0 ;;
+        esac
+    done < "$PROFILES_FILE"
+    return 1
+}
+
+selected_profile() {
+    [ -f "$SELECTED_FILE" ] && cat "$SELECTED_FILE" || true
+}
+
+# --- subcommand: auth list -----------------------------------------------
+
+cmd_auth_list() {
+    if [ "${PP_MOCK_PAC_FAIL_AUTH_LIST:-0}" = "1" ]; then
+        echo "Error: failed to read profile list" >&2
+        return 1
+    fi
+    echo "Index   Active   Kind        Name                    Environment URL"
+    echo "----    ------   ----------  ----------------------  -------------------"
+    local i=1 line
+    local sel
+    sel=$(selected_profile)
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ -z "$line" ] && continue
+        local name="${line%%=*}"
+        local url="${line#*=}"
+        local marker=" "
+        [ "$name" = "$sel" ] && marker="*"
+        printf '[%d]    %s        UNIVERSAL   %-22s  %s\n' "$i" "$marker" "$name" "$url"
+        i=$((i + 1))
+    done < "$PROFILES_FILE"
+}
+
+# --- subcommand: auth select ---------------------------------------------
+
+cmd_auth_select() {
+    local name=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --name) name="${2:-}"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    [ -z "$name" ] && { echo "Error: --name required" >&2; return 1; }
+    if ! profile_url "$name" >/dev/null; then
+        echo "Error: profile '$name' not found" >&2
+        return 1
+    fi
+    printf '%s' "$name" > "$SELECTED_FILE"
+    echo "Profile '$name' is now active."
+}
+
+# --- subcommand: auth create ---------------------------------------------
+
+cmd_auth_create() {
+    local name="" env_url=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --name)        name="${2:-}";    shift 2 ;;
+            --environment) env_url="${2:-}"; shift 2 ;;
+            *)             shift ;;
+        esac
+    done
+    [ -z "$name" ] && { echo "Error: --name required" >&2; return 1; }
+    [ -z "$env_url" ] && { echo "Error: --environment required" >&2; return 1; }
+    # If profile already exists, replace its URL.
+    if profile_url "$name" >/dev/null; then
+        local tmp
+        tmp=$(mktemp)
+        grep -v "^$name=" "$PROFILES_FILE" > "$tmp" || true
+        mv "$tmp" "$PROFILES_FILE"
+    fi
+    printf '%s=%s\n' "$name" "$env_url" >> "$PROFILES_FILE"
+    printf '%s' "$name" > "$SELECTED_FILE"
+    echo "Profile '$name' created."
+}
+
+# --- subcommand: org who -------------------------------------------------
+
+cmd_org_who() {
+    if [ "${PP_MOCK_PAC_FAIL_ORG_WHO:-0}" = "1" ]; then
+        echo "No profile selected. Run 'pac auth select --name <profile>' first." >&2
+        return 1
+    fi
+    local sel
+    sel=$(selected_profile)
+    if [ -z "$sel" ]; then
+        echo "No profile selected." >&2
+        return 1
+    fi
+    local url
+    if ! url=$(profile_url "$sel"); then
+        echo "Selected profile '$sel' has no recorded URL." >&2
+        return 1
+    fi
+    echo "Connected to..."
+    echo "  Name:            $sel"
+    echo "  Environment Url: $url"
+    echo "  Region:          unitedstates"
+}
+
+# --- subcommand: paportal list -------------------------------------------
+
+cmd_paportal_list() {
+    cat <<'EOF'
+Index  Website Name              Website Id                              Model Version
+-----  ------------------------  ------------------------------------    -------------
+[1]    Sample Site               00000000-0000-0000-0000-000000000001    Enhanced
+[2]    Another Site              00000000-0000-0000-0000-000000000002    Standard
+EOF
+}
+
+# --- subcommand: paportal download ---------------------------------------
+# Creates a minimal Power Pages site folder structure under --path.
+
+cmd_paportal_download() {
+    local path="" website_id="" model_version=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --path)         path="${2:-}";          shift 2 ;;
+            --webSiteId)    website_id="${2:-}";    shift 2 ;;
+            --modelVersion) model_version="${2:-}"; shift 2 ;;
+            *)              shift ;;
+        esac
+    done
+    [ -z "$path" ] && { echo "Error: --path required" >&2; return 1; }
+    [ -z "$website_id" ] && { echo "Error: --webSiteId required" >&2; return 1; }
+    local site_dir="$path/sample-site---sample-site"
+    mkdir -p "$site_dir/web-pages" "$site_dir/web-templates" "$site_dir/site-settings"
+    cat > "$site_dir/website.yml" <<'EOF'
+adx_name: Sample Site
+adx_websitelanguage: 1033
+EOF
+    echo "Downloaded portal: Sample Site (id $website_id, model $model_version)"
+    echo "  to: $site_dir"
+}
+
+# --- subcommand: paportal upload -----------------------------------------
+
+cmd_paportal_upload() {
+    local validate=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --validateBeforeUpload) validate=1; shift ;;
+            *) shift ;;
+        esac
+    done
+    if [ "$validate" = "1" ]; then
+        echo "Validating site..."
+        echo "Validation OK"
+    else
+        echo "Uploading site..."
+        echo "Upload complete"
+    fi
+}
+
+# --- subcommand: solution ------------------------------------------------
+
+cmd_solution_export() {
+    local name="" path=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --name) name="${2:-}"; shift 2 ;;
+            --path) path="${2:-}"; shift 2 ;;
+            *)      shift ;;
+        esac
+    done
+    [ -z "$path" ] && { echo "Error: --path required" >&2; return 1; }
+    # Produce a zip containing one file. Use printf instead of zip
+    # binary to keep the mock dependency-free.
+    printf 'PK\x03\x04' > "$path"  # ZIP local file header magic
+    echo "Exported solution: $name -> $path"
+}
+
+cmd_solution_unpack() {
+    local zipfile="" folder=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --zipfile) zipfile="${2:-}"; shift 2 ;;
+            --folder)  folder="${2:-}";  shift 2 ;;
+            *)         shift ;;
+        esac
+    done
+    [ -z "$folder" ] && { echo "Error: --folder required" >&2; return 1; }
+    mkdir -p "$folder/Entities" "$folder/Other"
+    cat > "$folder/Other/Solution.xml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<ImportExportXml>
+  <SolutionManifest>
+    <UniqueName>SampleSolution</UniqueName>
+    <Version>1.0.0.0</Version>
+  </SolutionManifest>
+</ImportExportXml>
+EOF
+    echo "Unpacked $zipfile to $folder"
+}
+
+cmd_solution_pack() {
+    local zipfile="" folder=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --zipfile) zipfile="${2:-}"; shift 2 ;;
+            --folder)  folder="${2:-}";  shift 2 ;;
+            *)         shift ;;
+        esac
+    done
+    [ -z "$zipfile" ] && { echo "Error: --zipfile required" >&2; return 1; }
+    [ -d "$folder" ] || { echo "Error: folder '$folder' does not exist" >&2; return 1; }
+    printf 'PK\x03\x04' > "$zipfile"
+    echo "Packed $folder to $zipfile"
+}
+
+cmd_solution_import() {
+    echo "Imported solution"
+}
+
+# --- dispatcher ----------------------------------------------------------
+
+main() {
+    local sub="${1:-}"
+    shift 2>/dev/null || true
+    case "$sub" in
+        auth)
+            local action="${1:-}"
+            shift 2>/dev/null || true
+            case "$action" in
+                list)   cmd_auth_list "$@" ;;
+                select) cmd_auth_select "$@" ;;
+                create) cmd_auth_create "$@" ;;
+                *)      echo "mock pac: unknown auth action: $action" >&2; return 2 ;;
+            esac
+            ;;
+        org)
+            local action="${1:-}"
+            shift 2>/dev/null || true
+            case "$action" in
+                who) cmd_org_who "$@" ;;
+                *)   echo "mock pac: unknown org action: $action" >&2; return 2 ;;
+            esac
+            ;;
+        paportal)
+            local action="${1:-}"
+            shift 2>/dev/null || true
+            case "$action" in
+                list)     cmd_paportal_list "$@" ;;
+                download) cmd_paportal_download "$@" ;;
+                upload)   cmd_paportal_upload "$@" ;;
+                *)        echo "mock pac: unknown paportal action: $action" >&2; return 2 ;;
+            esac
+            ;;
+        solution)
+            local action="${1:-}"
+            shift 2>/dev/null || true
+            case "$action" in
+                export) cmd_solution_export "$@" ;;
+                unpack) cmd_solution_unpack "$@" ;;
+                pack)   cmd_solution_pack "$@" ;;
+                import) cmd_solution_import "$@" ;;
+                *)      echo "mock pac: unknown solution action: $action" >&2; return 2 ;;
+            esac
+            ;;
+        --version|version)
+            echo "Microsoft PowerPlatform CLI (mock) Version: 0.0.0-mock"
+            ;;
+        *)
+            echo "mock pac: unknown subcommand: $sub" >&2
+            return 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/plugins/pp-sync/tests/test_pac_mocked.sh
+++ b/plugins/pp-sync/tests/test_pac_mocked.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Regression tests for pp subcommands that depend on pac, using a
+# mock pac script instead of a real Power Platform CLI install.
+#
+# This is the in-CI complement to tests/integration/test_pac_dependent.sh
+# (which runs against real pac + real projects on a developer machine).
+#
+# The mock lives at tests/mocks/pac. We prepend its directory to PATH
+# so pp invocations pick up the mock instead of any real pac install.
+# Each test gets its own state directory via PP_MOCK_PAC_STATE_DIR so
+# profile registrations don't leak between tests.
+#
+# Currently covers (chunk 1 — auth + org + paportal validate paths):
+#   - pp doctor (pac auth list + auth select + org who)
+#   - pp switch (pac auth select)
+#   - pp status (pac org who)
+#   - pp up --validate-only (pac paportal upload --validateBeforeUpload)
+#
+# Run from anywhere: ./plugins/pp-sync/tests/test_pac_mocked.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PP_BIN="$SCRIPT_DIR/../bin/pp"
+MOCK_DIR="$SCRIPT_DIR/mocks"
+MOCK_PAC="$MOCK_DIR/pac"
+
+[ -x "$MOCK_PAC" ] || { echo "Cannot find mock pac at $MOCK_PAC" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+TMPDIRS=()
+cleanup_tmpdirs() {
+    local tmp
+    for tmp in "${TMPDIRS[@]}"; do
+        rm -rf "$tmp"
+    done
+}
+trap cleanup_tmpdirs EXIT
+
+# Build a tmp config dir with one project AND a mock pac state dir
+# preloaded with that project's PROFILE. Echo the config dir; caller
+# scopes env vars to it.
+make_test_env() {
+    local profile="${1:-testprof}"
+    local env_url="${2:-https://test.crm.dynamics.com/}"
+    local tmp
+    tmp=$(mktemp -d)
+    TMPDIRS+=( "$tmp" )
+
+    # PP config
+    mkdir -p "$tmp/pp/projects" "$tmp/repo/site---site/web-pages"
+    {
+        printf 'NAME="testproj"\n'
+        printf 'REPO="%s/repo"\n' "$tmp"
+        printf 'SITE_DIR="site---site"\n'
+        printf 'PROFILE="%s"\n' "$profile"
+        printf 'ENV_URL="%s"\n' "$env_url"
+        printf 'WEBSITE_ID="00000000-0000-0000-0000-000000000001"\n'
+        printf 'MODEL_VERSION="2"\n'
+    } > "$tmp/pp/projects/testproj.conf"
+
+    # PAC state: register the profile so auth list/select/org-who work
+    mkdir -p "$tmp/pac"
+    printf '%s=%s\n' "$profile" "$env_url" > "$tmp/pac/profiles"
+    printf '%s' "$profile" > "$tmp/pac/selected"
+
+    printf '%s\n' "$tmp"
+}
+
+assert_pass() {
+    PASS=$((PASS + 1))
+    printf '  OK   %s\n' "$1"
+}
+
+assert_fail() {
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=( "$1" )
+    printf '  FAIL %s\n' "$1" >&2
+    [ -n "${2:-}" ] && printf '       %s\n' "$2" >&2 || true
+}
+
+# Helper: run pp with mock pac on PATH + scoped state dirs.
+# Args: <test_env_root> <pp args...>
+# Echoes pp output (stdout+stderr) and returns pp's exit code.
+run_pp() {
+    local env_root="$1"; shift
+    PATH="$MOCK_DIR:$PATH" \
+        PP_CONFIG_DIR="$env_root/pp" \
+        PP_MOCK_PAC_STATE_DIR="$env_root/pac" \
+        "$PP_BIN" "$@" 2>&1
+}
+
+# --- Section 1: pp doctor full pac path ---------------------------------
+
+echo "Section 1 — pp doctor with mock pac"
+echo
+
+env=$(make_test_env testprof)
+out=$(run_pp "$env" doctor testproj || true)
+
+case "$out" in
+    *"Profile testprof registered"*) assert_pass "doctor: profile detected as registered" ;;
+    *) assert_fail "doctor: profile-registered message missing" "out: $(printf '%s' "$out" | head -10)" ;;
+esac
+
+case "$out" in
+    *"Connected:"*) assert_pass "doctor: connected to env URL" ;;
+    *) assert_fail "doctor: 'Connected' line missing" ;;
+esac
+
+case "$out" in
+    *"Site content counts"*) assert_pass "doctor reaches Site content counts section" ;;
+    *) assert_fail "doctor doesn't reach final section" ;;
+esac
+
+# --- Section 2: pp doctor when profile NOT registered -------------------
+
+echo
+echo "Section 2 — pp doctor with unregistered profile"
+echo
+
+env=$(mktemp -d); TMPDIRS+=( "$env" )
+mkdir -p "$env/pp/projects" "$env/repo/site---site" "$env/pac"
+{
+    printf 'NAME="testproj"\n'
+    printf 'REPO="%s/repo"\n' "$env"
+    printf 'SITE_DIR="site---site"\n'
+    printf 'PROFILE="missing"\n'
+} > "$env/pp/projects/testproj.conf"
+# Empty profiles file — "missing" will not be found
+: > "$env/pac/profiles"
+
+out=$(run_pp "$env" doctor testproj || true)
+case "$out" in
+    *"Profile missing not registered"*|*"not registered"*)
+        assert_pass "doctor: detects unregistered profile"
+        ;;
+    *)
+        assert_fail "doctor: didn't surface unregistered-profile error" \
+            "out: $(printf '%s' "$out" | head -10)"
+        ;;
+esac
+
+# --- Section 3: pp switch sets active + auth-selects --------------------
+
+echo
+echo "Section 3 — pp switch with mock pac"
+echo
+
+env=$(make_test_env myprof)
+# switch sets active and runs pac auth select
+out=$(run_pp "$env" switch testproj || true)
+[ -f "$env/pp/active" ] && [ "$(cat "$env/pp/active")" = "testproj" ] \
+    && assert_pass "switch wrote active=testproj" \
+    || assert_fail "switch didn't write active correctly"
+
+# Mock pac state should now have myprof selected
+selected=$(cat "$env/pac/selected" 2>/dev/null || echo "")
+[ "$selected" = "myprof" ] && assert_pass "switch ran pac auth select --name myprof" \
+    || assert_fail "switch didn't auth-select" "selected='$selected'"
+
+# --- Section 4: pp status shows live env URL ----------------------------
+
+echo
+echo "Section 4 — pp status with mock pac"
+echo
+
+env=$(make_test_env myprof "https://acme-dev.crm.dynamics.com/")
+run_pp "$env" switch testproj >/dev/null 2>&1 || true
+out=$(run_pp "$env" status || true)
+case "$out" in
+    *"acme-dev.crm.dynamics.com"*)
+        assert_pass "status reports live env URL from pac org who"
+        ;;
+    *)
+        assert_fail "status doesn't report live env URL" \
+            "out: $(printf '%s' "$out" | head -5)"
+        ;;
+esac
+
+# --- Section 5: pp up --validate-only (mock pac upload) -----------------
+
+echo
+echo "Section 5 — pp up --validate-only with mock pac"
+echo
+
+env=$(make_test_env myprof)
+out=$(run_pp "$env" up testproj --validate-only || true)
+case "$out" in
+    *"Validation OK"*|*"validation"*|*"Validating"*)
+        assert_pass "up --validate-only invoked pac validate path"
+        ;;
+    *)
+        assert_fail "up --validate-only didn't reach pac validation" \
+            "out: $(printf '%s' "$out" | head -10)"
+        ;;
+esac
+
+# --- Section 6: pp down end-to-end with mock paportal download ----------
+# (Section 9 below covers failure injection.)
+
+echo
+echo "Section 6 — pp down with mock pac paportal download"
+echo
+
+env=$(make_test_env myprof)
+# pp down auto-confirms via PP_DOWN_NO_CONFIRM env, but pp doesn't honor
+# such a flag. Pipe `y` to confirm prompts.
+out=$(printf 'y\ny\n' | run_pp "$env" down testproj 2>&1 || true)
+# The mock creates sample-site---sample-site/ under the cwd. Verify the
+# download path was invoked (pp output mentions Downloaded or Sample).
+case "$out" in
+    *"Sample"*|*"Downloaded"*|*"download"*|*"Download"*)
+        assert_pass "down invoked pac paportal download"
+        ;;
+    *)
+        assert_fail "down didn't invoke download" \
+            "out: $(printf '%s' "$out" | head -5)"
+        ;;
+esac
+
+# --- Section 7: pp up (full upload) with mock pac -----------------------
+
+echo
+echo "Section 7 — pp up (full) with mock pac"
+echo
+
+env=$(make_test_env myprof)
+# Full upload (no --validate-only) — pipe y to confirm prompts.
+out=$(printf 'y\ny\n' | run_pp "$env" up testproj 2>&1 || true)
+case "$out" in
+    *"Upload complete"*|*"Uploading"*|*"upload"*)
+        assert_pass "up invoked pac paportal upload (full)"
+        ;;
+    *)
+        assert_fail "up didn't reach upload" \
+            "out: $(printf '%s' "$out" | head -5)"
+        ;;
+esac
+
+# --- Section 8: pp solution-down end-to-end with mock pac ---------------
+
+echo
+echo "Section 8 — pp solution-down with mock pac"
+echo
+
+env=$(make_test_env myprof)
+out=$(printf 'y\n' | run_pp "$env" solution-down testproj MySolution 2>&1 || true)
+case "$out" in
+    *"Exported"*|*"Unpacked"*|*"export"*|*"unpack"*)
+        assert_pass "solution-down invoked pac solution export+unpack"
+        ;;
+    *)
+        assert_fail "solution-down didn't reach pac" \
+            "out: $(printf '%s' "$out" | head -10)"
+        ;;
+esac
+
+# Verify the unpacked solution dir was created at the expected path
+[ -d "$env/repo/dataverse-schema/MySolution" ] && assert_pass "solution unpacked to expected path" \
+    || assert_fail "unpacked dir missing" \
+        "tree: $(find "$env/repo" -maxdepth 4 -type d 2>/dev/null | head -10)"
+
+# --- Section 9: failure injection ---------------------------------------
+
+echo
+echo "Section 9 — failure injection via PP_MOCK_PAC_FAIL_*"
+echo
+
+env=$(make_test_env myprof)
+# Inject auth-list failure
+out=$(PP_MOCK_PAC_FAIL_AUTH_LIST=1 run_pp "$env" doctor testproj || true)
+# pp doctor uses pac auth list to verify the profile; with auth list
+# failing, the "Profile X registered" check should NOT fire.
+case "$out" in
+    *"Profile myprof registered"*)
+        assert_fail "auth list failure didn't propagate" "out: $out"
+        ;;
+    *)
+        assert_pass "auth list failure surfaced (pp didn't claim profile registered)"
+        ;;
+esac
+
+# --- Summary -----------------------------------------------------------
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+    printf '%d/%d passed\n' "$PASS" "$((PASS + FAIL))"
+    exit 0
+else
+    printf '%d/%d passed; failures: %s\n' "$PASS" "$((PASS + FAIL))" "${FAIL_NAMES[*]}" >&2
+    exit 1
+fi

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.8.0"
+        "version": "2.9.0"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.1.0",
+        "pp-sync": "2.2.0",
         "pp-permissions-audit": "1.5.4"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.8.0"
+        "pp_permissions_audit_ci_ref": "v2.9.0"
     }
 }


### PR DESCRIPTION
First chunk of pac-mocking work. Closes the "pac happy paths only run locally" gap.

## What's new

| File | Purpose |
|---|---|
| `tests/mocks/pac` | 250-line shell mock of pac CLI |
| `tests/mocks/README.md` | What's mocked, state dir layout, failure injection |
| `tests/test_pac_mocked.sh` | 13 tests exercising mocked path |
| `.github/workflows/plugin-validate.yml` | New "Run pp pac-mocked tests" CI step |

## What's mocked

Full subset pp-sync invokes:
- `pac auth list` / `select` / `create`
- `pac org who`
- `pac paportal list` / `download` / `upload` (incl. `--validateBeforeUpload`)
- `pac solution export` / `unpack` / `pack` / `import`
- `pac --version`

Backed by `$PP_MOCK_PAC_STATE_DIR` for stateful multi-call coherence. Failure injection via `PP_MOCK_PAC_FAIL_AUTH_LIST=1` etc.

## What's now CI-defended

| pp subcommand | Was CI-covered? | Now? |
|---|---|---|
| `pp doctor` (pac auth path) | ❌ no | ✅ yes |
| `pp switch` (auth select) | ❌ no | ✅ yes |
| `pp status` (org who) | ❌ no | ✅ yes |
| `pp up --validate-only` | ❌ no | ✅ yes |
| `pp down` (paportal download) | ❌ no | ✅ yes |
| `pp up` (paportal upload) | ❌ no | ✅ yes |
| `pp solution-down` (export+unpack) | ❌ no | ✅ yes |

## Test count: 184 (was 171)

| Suite | Tests |
|---|---|
| audit.py | 26 |
| test_load_project.sh | 21 |
| test_register_atomic.sh | 6 |
| test_journal_url_validation.sh | 16 |
| test_subcommand_safety.sh | 23 |
| test_command_flows.sh | 66 |
| test_install_script.sh | 13 |
| **test_pac_mocked.sh (NEW)** | **13** |

## Two-layer coverage strategy

- **CI:** mocked tests on every PR — fast, deterministic, no external deps
- **Local:** `tests/integration/test_pac_dependent.sh` against real pac before each release

## Versions

| Component | Before | After |
|---|---|---|
| Marketplace | 2.8.0 | **2.9.0** |
| pp-sync | 2.1.0 | **2.2.0** |