### PR TITLE
v2.9.4: 15th review pass — 5 real bugs fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.9.4] — 2026-04-30
+
+Fifteenth review pass. 5 real bugs surfaced + fixed. Test count: **218** (was 211).
+
+### Fixed (pp-sync v2.2.4)
+
+- **`pp setup` aborted under `set -euo pipefail` when zero PAC profiles were registered.** The `echo "$pac_output" | grep -E '^\[[0-9]+\]' | head -10` pipeline tripped pipefail when grep found no matches (the empty-profile case is valid state for first-time users — they haven't run `pac auth create` yet). Same pattern at line 483 in the candidate-walkthrough loop. Both pipelines now end with `|| true`. Real-user impact: anyone running `pp setup` for the first time without any registered PAC profiles saw the script die silently after listing the (empty) profiles.
+- **`pp solution-down|up` accepted unvalidated solution names from CLI args and the interactive name branch.** A user typing `pp solution-down acme '../../etc/foo'` (or selecting non-numeric input at the multi-solution prompt) passed unchecked text into `mkdir`/`mv`/`rm -rf` paths under `$SCHEMA_DIR`. `format_solutions_array` validates entries at registration time but those code paths bypass it. Both subcommands now call `validate_identifier "Solution name" "$solution" '^[A-Za-z0-9_.-]+$'` after the resolution branch. Self-attack severity (the user types the bad input themselves), but real path-traversal mechanism.
+- **`pp generate-page` accepted whitespace-only and pure-dot/dash names** that passed `validate_identifier` but slugified to an empty string, causing `page_dir` to resolve to `$SITE_DIR/web-pages/` itself. On a fresh portal source (where `web-pages/` doesn't exist), the function then wrote `.webpage.yml` files directly into the parent directory. Added an explicit empty-slug check after slug derivation.
+- **`install.sh` PATH check used unanchored regex grep (false positives).** `grep -qx "$BIN_DIR"` treated the value as a basic regex; the `.` in `~/.local/bin` matched any character, so `~/zlocal/bin` (a path the user does NOT have) was treated as already in PATH. Switched to `grep -qFx` (fixed-string mode).
+- **`load_project` aborted under `set -u` when `$HOME` was unset** (chroot, `env -i`, scratch container). The new `${REPO/#~/$HOME}` and `${REPO/#\$HOME/$HOME}` expansions referenced `$HOME` directly. Now defaults via `${HOME:-}` and skips both expansions if empty.
+
+### Tests added (test count: 218, was 211)
+
+- 4 cases in `test_subcommand_safety.sh` exercising the new solution-name CLI-arg validation (path traversal, slash injection, shell metachar, semicolon).
+- 3 cases in `test_subcommand_safety.sh` for the generate-page empty-slug rejection (whitespace-only, pure dots, pure dashes).
+
+### Documentation
+
+- **`tests/README.md`** test-count table updated: `test_load_project.sh` 15 → 21, `test_command_flows.sh` 66 → 78, `test_subcommand_safety.sh` 23 → 30. Description for `bin/pp` updated from "1500-line" to "~1800-line".
+- **`tests/mocks/README.md`** mock line-count updated 250 → 330.
+
+### Pattern note
+
+This is the 15th review pass and the bug count per round is plateauing — no architectural issues, no new attack surfaces. The 5 bugs found here all fall into known categories already extensively covered: pipefail aborts (1), input-validation bypasses (2), edge cases in identifier handling (1), defensive-default omissions (1). The ratio of "scrutinized assertion : surfaced bug" for the top-level adversarial review was about 7:1 — substantially lower bug-yield than earlier rounds.
+
 ## [2.9.3] — 2026-04-29
 
 Chunk 4 of pac mocking — `pp setup` detection phase coverage. Test count: **211** (was 204).
@@ -554,6 +580,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.9.4]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.4
 [2.9.3]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.3
 [2.9.2]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.2
 [2.9.1]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,16 +125,20 @@ Every audit rule shipped today has both positive coverage (rule fires on a fixtu
 
 ## Test suites
 
-The marketplace runs four test suites in CI. Run any of them locally:
+The marketplace runs multiple test suites in CI. Run the core ones locally:
 
 ```bash
 # pp-permissions-audit — Python unit tests (audit.py rule logic)
 python3 -m unittest plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/test_audit.py
 
 # pp-sync — bash regression tests
-bash plugins/pp-sync/tests/test_load_project.sh           # 12 cases — strict conf parser
+bash plugins/pp-sync/tests/test_load_project.sh           # strict conf parser
 bash plugins/pp-sync/tests/test_register_atomic.sh        # 6 cases — pp project add atomicity
 bash plugins/pp-sync/tests/test_journal_url_validation.sh # 16 cases — journal URL hardening
+bash plugins/pp-sync/tests/test_subcommand_safety.sh      # subcommand edge cases
+bash plugins/pp-sync/tests/test_command_flows.sh          # happy-path + error-path flows
+bash plugins/pp-sync/tests/test_install_script.sh         # installer behavior
+bash plugins/pp-sync/tests/test_pac_mocked.sh            # mocked pac CLI flows
 ```
 
 The bash suites use fixture files under `plugins/pp-sync/tests/fixtures/` and a source-safe pattern that loads `bin/pp` without dispatching commands. See `plugins/pp-sync/tests/README.md` for fixture conventions and how to add a new test.
@@ -143,7 +147,7 @@ When adding a new `pp` subcommand or registration path, add fixtures + assertion
 
 ## Integration tests (local-only)
 
-Beyond the four bash suites that run in CI, `plugins/pp-sync/tests/integration/test_pac_dependent.sh` exercises pp subcommands against a real `pac` install + a registered project. **Run this before each release** as a smoke gate:
+Beyond the in-CI unit and regression suites, `plugins/pp-sync/tests/integration/test_pac_dependent.sh` exercises pp subcommands against a real `pac` install + a registered project. **Run this before each release** as a smoke gate:
 
 ```bash
 bash plugins/pp-sync/tests/integration/test_pac_dependent.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Status |
 |---|---|
-| 2.7.x | Active — security fixes shipped within days of disclosure |
-| 2.6.x and earlier | **Unsupported** — upgrade to 2.7.x |
+| 2.9.x | Active — security fixes shipped within days of disclosure |
+| 2.8.x and earlier | **Unsupported** — upgrade to 2.9.x |
 
 The 2.7.0 release (2026-04-29) closed a CVE-class arbitrary-code-execution sink in the `pp-sync` conf loader (`source` → strict parser). All earlier versions of `pp-sync` are vulnerable when run against a hand-edited or attacker-tampered project conf file. **Upgrade required.**
 
@@ -48,11 +48,12 @@ We will:
 
 ## Security-relevant test surfaces
 
-The marketplace ships **161 regression tests** including:
-- 7 attack-vector fixtures for the `pp-sync` conf parser (command substitution, backticks, env-var poisoning, control characters)
-- 16 URL-shape and same-repo enforcement tests for `pp journal note|close` (subdomain spoof, port injection, scheme downgrade, prefix confusion, path traversal)
-- 10 page-name validation tests for `pp generate-page` (path traversal, injection, every shell metacharacter)
-- 8 atomic-registration tests for `pp project add` / `pp setup` (no partial conf writes on rejection)
+The marketplace ships **211 regression tests** across Python, bash, and pac-mocked coverage, including:
+- conf-parser attack-vector fixtures for `pp-sync` (`$(...)`, backticks, env-var poisoning, control characters, literal-metachar resolution)
+- URL-shape and same-repo enforcement tests for `pp journal note|close` (subdomain spoof, port injection, scheme downgrade, prefix confusion, path traversal)
+- page-name validation tests for `pp generate-page` (path traversal, injection, shell metacharacters)
+- atomic-registration tests for `pp project add` / `pp setup` (no partial conf writes on rejection)
+- command-flow, install-script, and pac-mocked tests that exercise real CLI behavior beyond isolated parser rules
 
 If you find a path through the parser, the URL validator, the page-name validator, or the registration flow that the existing tests don't cover, that's the highest-value report we can receive.
 

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.9.3` by default)
+- Fetches the audit script from a pinned tag (`v2.9.4` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.9.3'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.9.4'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.9.3/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.9.4/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.9.3/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.9.4/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.9.3'   (recommended for production projects)
+#   AUDIT_REF:  'v2.9.4'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.9.3'
+  AUDIT_REF:  'v2.9.4'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/README.md
+++ b/plugins/pp-sync/README.md
@@ -66,7 +66,7 @@ Full schema reference: [`skills/pp-sync/references/cli-reference.md`](skills/pp-
 
 ## Tests
 
-`plugins/pp-sync/tests/` ships regression coverage across five bash suites covering parser correctness, registration atomicity, URL validation, command flows, and subcommand safety. Run locally:
+`plugins/pp-sync/tests/` ships regression coverage across seven bash suites covering parser correctness, registration atomicity, URL validation, command flows, subcommand safety, installer behavior, and mocked `pac` CLI flows. Run locally:
 
 ```bash
 bash plugins/pp-sync/tests/test_load_project.sh
@@ -74,6 +74,8 @@ bash plugins/pp-sync/tests/test_register_atomic.sh
 bash plugins/pp-sync/tests/test_journal_url_validation.sh
 bash plugins/pp-sync/tests/test_command_flows.sh
 bash plugins/pp-sync/tests/test_subcommand_safety.sh
+bash plugins/pp-sync/tests/test_install_script.sh
+bash plugins/pp-sync/tests/test_pac_mocked.sh
 ```
 
 See [`tests/README.md`](tests/README.md) for fixture conventions and how to add tests for new subcommands.

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -310,9 +310,14 @@ load_project() {
     # and `$HOME` was expanded by the shell). Both expansions are pure
     # string substitution — only the matching prefix is replaced; no
     # other `$VAR` references are processed and no shell evaluation
-    # occurs.
-    REPO="${REPO/#~/$HOME}"
-    REPO="${REPO/#\$HOME/$HOME}"
+    # occurs. The `${HOME:-}` defaulting protects against `set -u` aborts
+    # in chroot / `env -i` / scratch-container environments where HOME
+    # may legitimately be unset.
+    local home_dir="${HOME:-}"
+    if [ -n "$home_dir" ]; then
+        REPO="${REPO/#~/$home_dir}"
+        REPO="${REPO/#\$HOME/$home_dir}"
+    fi
 
     # Session safety for journaling only. Do not block non-interactive pp flows.
     local board_verify_key=""
@@ -408,7 +413,12 @@ cmd_setup() {
     fi
     local pac_output
     pac_output=$(pac auth list 2>/dev/null) || die "pac auth list failed"
-    echo "$pac_output" | grep -E '^\[[0-9]+\]' | head -10
+    # `|| true` on the pipeline: when the user has zero PAC profiles
+    # registered, grep finds no matches and exits 1, which pipefail
+    # propagates and (under set -e) would abort setup before reaching
+    # the candidate-scan section. Empty profile list is valid state —
+    # the user just hasn't run `pac auth create` yet.
+    echo "$pac_output" | grep -E '^\[[0-9]+\]' | head -10 || true
     echo
 
     # Detect candidate site folders
@@ -480,7 +490,7 @@ cmd_setup() {
 
         # Profile selection
         echo "PAC profiles available:"
-        echo "$pac_output" | grep -E '^\[[0-9]+\]' | awk '{print "  " $0}' | head
+        echo "$pac_output" | grep -E '^\[[0-9]+\]' | awk '{print "  " $0}' | head || true
         echo
         read -r -p "PAC profile name (exact, from list): " pac_profile
         [ -z "$pac_profile" ] && { warn "Skipping (no profile given)"; continue; }
@@ -1056,6 +1066,13 @@ cmd_solution_down() {
         fi
     fi
 
+    # Validate solution name — it flows into mkdir / mv / rm -rf paths
+    # under $SCHEMA_DIR. A `../foo` value would escape into parent dirs.
+    # `format_solutions_array` enforces this at registration time, but
+    # CLI args (`pp solution-down acme '../escape'`) and the interactive
+    # name branch bypass that.
+    validate_identifier "Solution name" "$solution" '^[A-Za-z0-9_.-]+$'
+
     info "${BOLD}Solution down: $name / $solution${RST}"
     cd_repo_root "$REPO"
     confirm_pac_profile "$PROFILE" >/dev/null
@@ -1125,6 +1142,11 @@ cmd_solution_up() {
             fi
         fi
     fi
+
+    # Validate solution name — same path-traversal protection as
+    # cmd_solution_down. CLI arg or interactive name input bypasses
+    # the registration-time validation otherwise.
+    validate_identifier "Solution name" "$solution" '^[A-Za-z0-9_.-]+$'
 
     info "${BOLD}Solution up: $name / $solution${RST}"
     cd_repo_root "$REPO"
@@ -1328,7 +1350,13 @@ cmd_generate_page() {
     # Clean the name for folders/filenames: "My Awesome Page" -> "my-awesome-page"
     local slug
     slug=$(echo "$page_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//')
-    
+    # Reject names that slugify to an empty string (whitespace-only,
+    # or composed entirely of characters the slugifier strips). The
+    # earlier validate_identifier accepts " " and "." but those would
+    # produce an empty slug → page_dir would be SITE_DIR/web-pages/
+    # itself, polluting the parent.
+    [ -n "$slug" ] || die "Page name produces an empty slug after normalization: '$page_name'"
+
     local page_dir="$SITE_DIR/web-pages/$slug"
     [ -d "$page_dir" ] && die "Page folder already exists: $page_dir"
 

--- a/plugins/pp-sync/install.sh
+++ b/plugins/pp-sync/install.sh
@@ -52,7 +52,7 @@ touch "$CONFIG_DIR/aliases"
 echo "${GRN}✓${RST} Config dir: $CONFIG_DIR"
 
 # 4. PATH check
-if ! echo "$PATH" | tr ':' '\n' | grep -qx "$BIN_DIR"; then
+if ! echo "$PATH" | tr ':' '\n' | grep -qFx "$BIN_DIR"; then
     echo
     echo "${YLW}⚠${RST} $BIN_DIR is not in your PATH."
     echo "Add this to your shell rc (~/.zshrc, ~/.bashrc):"

--- a/plugins/pp-sync/tests/README.md
+++ b/plugins/pp-sync/tests/README.md
@@ -1,16 +1,18 @@
 # pp-sync test suites
 
-Bash regression tests for `pp` CLI behavior. Five suites run in CI on every PR via `.github/workflows/plugin-validate.yml`.
+Bash regression tests for `pp` CLI behavior. Seven suites run in CI on every PR via `.github/workflows/plugin-validate.yml`.
 
 ## Suites
 
 | File | Tests | What it verifies |
 |---|---|---|
-| `test_load_project.sh` | 15 | Strict key=value parser correctness. Includes attack-vector fixtures (`$(...)`, backticks, control chars, allowlist bypass attempts) plus literal-metachar project-resolution checks verifying that command-injection payloads are stored as literal strings, never executed. |
+| `test_load_project.sh` | 21 | Strict key=value parser correctness. Includes attack-vector fixtures (`$(...)`, backticks, control chars, allowlist bypass attempts), literal-metachar project-resolution checks, parser edge cases (leading whitespace, only-comments, no-trailing-newline), and the `$HOME` backward-compat expansion path. |
 | `test_register_atomic.sh` | 6 | `pp project add` atomicity. Asserts that rejected runs (invalid project name / PAC profile / solution / alias) leave zero files behind in `$PP_CONFIG_DIR/projects/`. |
 | `test_journal_url_validation.sh` | 16 | `validate_issue_url_for_current_repo()` URL-shape regex + same-repo enforcement. Mocks `gh repo view` to test cross-repo hijack rejection without a real git checkout. Covers subdomain spoof, port injection, http downgrade, prefix confusion, path traversal, non-issue URLs, and 9 other attack vectors. |
-| `test_command_flows.sh` | 66 | Happy-path and error-path coverage for command dispatch: project resolution, `show`, `list`, alias operations, project removal, switch/status, journal init, `generate-page`, `sync-pages`, and help output. |
-| `test_subcommand_safety.sh` | 23 | Negative and edge-case coverage for subcommands beyond the parser: page-name traversal/injection rejection, journal `Issue:` extraction invariants, solution-pick range validation, and doctor pipefail tolerance. |
+| `test_command_flows.sh` | 78 | Happy-path and error-path coverage for command dispatch: project resolution, `show`, `list`, alias operations, project removal, switch/status, journal init, `generate-page` (incl. content correctness + JS/CSS placeholders), `sync-pages`, `setup` detection phase, and help output. |
+| `test_subcommand_safety.sh` | 30 | Negative and edge-case coverage for subcommands beyond the parser: page-name traversal/injection rejection (incl. empty-slug rejection), solution-name CLI-arg validation, journal `Issue:` extraction invariants, solution-pick range validation, and doctor pipefail tolerance. |
+| `test_install_script.sh` | 13 | Installer UX and safety: fresh install, idempotent re-run, non-symlink backup behavior, PATH guidance, and installed `pp help` smoke check. |
+| `test_pac_mocked.sh` | 23 | Mocked `pac` CLI flows in CI: doctor, switch/status, download/upload, solution export/import, validate-only upload, diff, and failure-injection paths without requiring a real tenant. |
 
 Run any suite locally:
 
@@ -53,7 +55,7 @@ When the file is sourced, `return` succeeds (we're inside a sourced script), so 
 
 ## Why bash and not pytest
 
-The system under test is `bin/pp`, a 1500-line bash script. Sourcing it from bash gives direct access to its functions and variables. Re-implementing the same harness in Python would need a subprocess shim that hides the very behavior we want to verify (function-table state, IFS handling, dynamic scoping) — exactly the things that surface real bugs in shell code.
+The system under test is `bin/pp`, a ~1800-line bash script. Sourcing it from bash gives direct access to its functions and variables. Re-implementing the same harness in Python would need a subprocess shim that hides the very behavior we want to verify (function-table state, IFS handling, dynamic scoping) — exactly the things that surface real bugs in shell code.
 
 The Python suite (`audit.py`) tests Python code; the bash suites test bash code.
 

--- a/plugins/pp-sync/tests/mocks/README.md
+++ b/plugins/pp-sync/tests/mocks/README.md
@@ -70,4 +70,4 @@ Add new subcommands to `pac` as new `cmd_<sub>_<action>()` functions and dispatc
 
 ## Why this is a shell script and not a Python tool
 
-Same reason the test suites are bash: it runs on every machine that has bash, with no `pip install`. Tests that depend on the mock add no new dependencies to CI. The mock is ~250 lines — short enough to read end-to-end before trusting.
+Same reason the test suites are bash: it runs on every machine that has bash, with no `pip install`. Tests that depend on the mock add no new dependencies to CI. The mock is ~330 lines — short enough to read end-to-end before trusting.

--- a/plugins/pp-sync/tests/test_subcommand_safety.sh
+++ b/plugins/pp-sync/tests/test_subcommand_safety.sh
@@ -82,7 +82,7 @@ run_page_name_reject() {
     output=$(PP_CONFIG_DIR="$conf" "$PP_BIN" generate-page test "$page_name" 2>&1 || true)
     # Validation must reject — script either dies with "must match" or
     # the explicit traversal-shape error.
-    if [[ "$output" != *"must match"* ]] && [[ "$output" != *"may not contain"* ]]; then
+    if [[ "$output" != *"must match"* ]] && [[ "$output" != *"may not contain"* ]] && [[ "$output" != *"empty slug"* ]]; then
         FAIL=$((FAIL + 1))
         FAIL_NAMES+=( "$label" )
         printf '  FAIL %s — accepted bad name; output: %s\n' "$label" "$output" >&2
@@ -108,6 +108,14 @@ run_page_name_reject "semicolon injection: Foo;rm"     'Foo;rm -rf /'
 run_page_name_reject "double-quote injection"          'Foo"; rm; "'
 run_page_name_reject "command substitution: \$(...)"   'Foo$(touch /tmp/page-pwn)'
 run_page_name_reject "backtick: \`...\`"               'Foo`touch /tmp/page-pwn`'
+
+# Names that pass identifier validation but slugify to empty —
+# v2.9.4 added an explicit empty-slug check after identifier
+# validation. Without this guard, the slug would be "" and page_dir
+# would resolve to SITE_DIR/web-pages/ itself, polluting the parent.
+run_page_name_reject "whitespace-only name"            "   "
+run_page_name_reject "pure dots"                       "..."
+run_page_name_reject "pure dashes"                     "---"
 
 # Verify the trap files were NOT created
 if [ -e /tmp/page-pwn ]; then
@@ -276,6 +284,38 @@ run_solution_pick "pick zero (0)"                "0"   "reject"
 run_solution_pick "pick way out of range (1000)" "1000" "reject"
 run_solution_pick "pick valid (1)"               "1"   "accept"
 run_solution_pick "pick valid (2)"               "2"   "accept"
+
+# CLI arg path traversal — solution name from `pp solution-down acme X`
+# must validate against [A-Za-z0-9_.-]+
+echo
+echo "Section 3b — solution name CLI arg validation"
+echo
+
+run_solution_cli_arg() {
+    local label="$1" arg="$2"
+    local conf
+    conf=$(make_project test '"FooSolution"')
+    local out
+    out=$(PP_CONFIG_DIR="$conf" "$PP_BIN" solution-down test "$arg" 2>&1 || true)
+    if [[ "$out" == *"must match"* ]]; then
+        PASS=$((PASS + 1))
+        printf '  OK   %s (rejected: %s)\n' "$label" "$arg"
+    elif [[ "$out" == *"unbound variable"* ]] || [[ "$out" == *"bad array"* ]]; then
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "$label" )
+        printf '  FAIL %s — bash crash instead of friendly reject\n' "$label" >&2
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=( "$label" )
+        printf '  FAIL %s — accepted bad solution name\n' "$label" >&2
+        printf '       out: %s\n' "$out" >&2
+    fi
+}
+
+run_solution_cli_arg "path traversal: ../../etc/foo"    "../../etc/foo"
+run_solution_cli_arg "slash injection: Foo/Bar"         "Foo/Bar"
+run_solution_cli_arg "shell metachar: Foo\$bar"         'Foo$bar'
+run_solution_cli_arg "semicolon: Foo;rm"                'Foo;rm'
 
 # --- Section 4: cmd_doctor outside git tree ------------------------------
 

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.9.3"
+        "version": "2.9.4"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.2.3",
+        "pp-sync": "2.2.4",
         "pp-permissions-audit": "1.5.5"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.9.3"
+        "pp_permissions_audit_ci_ref": "v2.9.4"
     }
 }


### PR DESCRIPTION
Adversarial review + doc audit found 5 real bugs. All fixed. **218 CI tests** total.

| Severity | Bug | Fix |
|---|---|---|
| MEDIUM | `pp setup` aborted under `set -e + pipefail` when zero PAC profiles registered | `\|\| true` on the two grep pipelines |
| MEDIUM | `pp solution-down/up` accepted unvalidated solution name from CLI args / interactive name pick (path traversal) | `validate_identifier` after resolution |
| LOW | `pp generate-page` accepted whitespace-only / pure-dot/dash names that slugified to empty | Explicit empty-slug check |
| LOW | `install.sh` PATH check used unanchored regex grep (false positives on `.` in `$BIN_DIR`) | `grep -qFx` |
| LOW | `load_project` aborted under `set -u` when `$HOME` was unset (chroot, scratch container) | `${HOME:-}` defaulting |

## Tests added (218 total, was 211)

- 4 solution-name CLI-arg validation cases (test_subcommand_safety.sh)
- 3 empty-slug page-name rejection cases (test_subcommand_safety.sh)

## Docs corrected

- `tests/README.md` test counts: 15→21, 66→78, 23→30
- `tests/README.md` `bin/pp` line count: 1500 → ~1800
- `tests/mocks/README.md` mock line count: 250 → 330

## Pattern note

15th review pass; bug-yield ratio plateauing. The 5 found here all fall into known categories (pipefail aborts, input-validation bypasses, edge cases, defensive-default omissions). No new architectural issues, no new attack surfaces.

| | Before | After |
|---|---|---|
| Marketplace | 2.9.3 | **2.9.4** |
| pp-sync | 2.2.3 | **2.2.4** |