### PR TITLE
v2.11.0: pac contract test suite (mock-vs-real drift detection)

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -183,6 +183,11 @@ jobs:
           bash plugins/pp-sync/tests/test_journal_state.sh
           echo "OK    pp journal-state tests pass"
 
+      - name: Run pac contract tests (mock mode)
+        run: |
+          bash plugins/pp-sync/tests/test_pac_contract.sh
+          echo "OK    pac contract tests pass against mock"
+
       - name: Bash syntax check
         run: |
           fail=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.11.0] — 2026-04-30
+
+Closes the "real-pac behavior diff the mock can't catch" gap from v2.10.0's "remaining gaps" list. New contract test suite — runnable against either the mock (default, CI) or real `pac` (release-prep) — defines what pp depends on from each pac subcommand and verifies the dependency holds.
+
+### Added (pp-sync v2.4.0)
+
+- **`tests/test_pac_contract.sh`** — 10 contract assertions across 6 sections covering every pac subcommand pp invokes:
+  - `auth list` — row shape (`UNIVERSAL <profile>` substring), URL presence
+  - `auth select` — exit-code semantics for known/unknown profiles
+  - `org who` — `Environment Url:` line shape and URL parseability
+  - `paportal upload --validateBeforeUpload` — validation message presence
+  - `solution unpack` — produces target folder + `Entities/` subdir pp counts
+  - `pac --version` / `pac help` — callability
+
+  Two run modes:
+
+  ```bash
+  bash plugins/pp-sync/tests/test_pac_contract.sh            # mock (CI)
+  PP_PAC_REAL=1 bash plugins/pp-sync/tests/test_pac_contract.sh   # real pac
+  ```
+
+  CI runs the mock mode on every PR. **Maintainers run the real-pac mode before each release** to catch drift when Microsoft changes pac output formats. Mode-specific assertions skip cleanly when they'd mutate user state (e.g., `auth select` to a real profile, `paportal upload` against a real environment).
+
+### Bug surfaced + fixed (in this same release)
+
+Running the contract suite against real pac immediately surfaced a discrepancy: real pac's `auth list` has 9 columns (Index/Active/Kind/Name/User/Cloud/Type/Environment/URL) while the mock had 5 (Index/Active/Kind/Name/URL). The original contract assertion `UNIVERSAL <name> <url>` was over-strict and would have rejected real pac as drifted — but pp's actual `grep -qE "UNIVERSAL[[:space:]]+\${PROFILE}\b"` doesn't depend on column 5 being a URL.
+
+Fix: relaxed the contract assertion to match what pp actually parses (`UNIVERSAL <name>` substring), with a separate soft check for "URL appears anywhere on the row." This is the right shape — **the contract reflects the dependency, not the format.**
+
+### Documentation
+
+- `CONTRIBUTING.md` "pac contract tests" section documents the two run modes, the release-prep workflow, and the meaning of skipped assertions.
+
+### CI
+
+- New "Run pac contract tests (mock mode)" step. Total CI test count: **238** (was 228).
+
+### Why this closes the v2.10.0 gap
+
+v2.10.0's CHANGELOG acknowledged: "Real-pac behavior diffs the mock can't catch. Covered by local integration suite." That coverage was correct but reactive — drift would only surface when a maintainer happened to run the integration suite. The contract suite makes the dependency explicit in code: any real pac that fails this contract will break pp's parsers, so the maintainer can fix one or the other before users hit the drift.
+
 ## [2.10.0] — 2026-04-30
 
 Closes the two known journal-tracking gaps that v2.9.4 acknowledged but didn't fix.
@@ -607,6 +648,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.11.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.11.0
 [2.10.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.10.0
 [2.9.4]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.4
 [2.9.3]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,11 +139,26 @@ bash plugins/pp-sync/tests/test_subcommand_safety.sh      # subcommand edge case
 bash plugins/pp-sync/tests/test_command_flows.sh          # happy-path + error-path flows
 bash plugins/pp-sync/tests/test_install_script.sh         # installer behavior
 bash plugins/pp-sync/tests/test_pac_mocked.sh            # mocked pac CLI flows
+bash plugins/pp-sync/tests/test_journal_state.sh         # journal state + concurrency
 ```
 
 The bash suites use fixture files under `plugins/pp-sync/tests/fixtures/` and a source-safe pattern that loads `bin/pp` without dispatching commands. See `plugins/pp-sync/tests/README.md` for fixture conventions and how to add a new test.
 
 When adding a new `pp` subcommand or registration path, add fixtures + assertions to the matching suite. The suites are wired into `.github/workflows/plugin-validate.yml` automatically.
+
+## pac contract tests
+
+`plugins/pp-sync/tests/test_pac_contract.sh` defines what `pp` expects from each `pac` subcommand — output patterns, exit codes, filesystem effects. Two run modes:
+
+```bash
+bash plugins/pp-sync/tests/test_pac_contract.sh            # mock mode (CI)
+PP_PAC_REAL=1 bash plugins/pp-sync/tests/test_pac_contract.sh
+                                                            # real pac mode
+```
+
+CI runs the mock mode on every PR, verifying that `tests/mocks/pac` still satisfies the contract. **Run the real-pac mode before each release** (after `pac install latest`) — it catches the case where Microsoft ships a new `pac` version that changes output formats. If real pac fails the contract, either pp's parsers need updating OR the contract assertions are over-strict and need to relax.
+
+A passing real-pac run with skips is normal — most assertions skip in real mode because they'd mutate user state (e.g., `auth select` against an unknown profile, `paportal upload` against a real environment). The output-shape assertions (`auth list` row shape, `pac help` callable) run in both modes and gate the contract.
 
 ## Integration tests (local-only)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Status |
 |---|---|
-| 2.9.x | Active — security fixes shipped within days of disclosure |
-| 2.8.x and earlier | **Unsupported** — upgrade to 2.9.x |
+| 2.10.x | Active — security fixes shipped within days of disclosure |
+| 2.9.x and earlier | **Unsupported** — upgrade to 2.10.x |
 
 The 2.7.0 release (2026-04-29) closed a CVE-class arbitrary-code-execution sink in the `pp-sync` conf loader (`source` → strict parser). All earlier versions of `pp-sync` are vulnerable when run against a hand-edited or attacker-tampered project conf file. **Upgrade required.**
 
@@ -48,12 +48,12 @@ We will:
 
 ## Security-relevant test surfaces
 
-The marketplace ships **211 regression tests** across Python, bash, and pac-mocked coverage, including:
+The marketplace ships **228 regression tests** across Python, bash, pac-mocked, and journal-state coverage, including:
 - conf-parser attack-vector fixtures for `pp-sync` (`$(...)`, backticks, env-var poisoning, control characters, literal-metachar resolution)
 - URL-shape and same-repo enforcement tests for `pp journal note|close` (subdomain spoof, port injection, scheme downgrade, prefix confusion, path traversal)
 - page-name validation tests for `pp generate-page` (path traversal, injection, shell metacharacters)
 - atomic-registration tests for `pp project add` / `pp setup` (no partial conf writes on rejection)
-- command-flow, install-script, and pac-mocked tests that exercise real CLI behavior beyond isolated parser rules
+- command-flow, install-script, pac-mocked, and journal-state tests that exercise real CLI behavior beyond isolated parser rules
 
 If you find a path through the parser, the URL validator, the page-name validator, or the registration flow that the existing tests don't cover, that's the highest-value report we can receive.
 

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.10.0` by default)
+- Fetches the audit script from a pinned tag (`v2.11.0` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.10.0'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.11.0'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.10.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.11.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.10.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.11.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.10.0'   (recommended for production projects)
+#   AUDIT_REF:  'v2.11.0'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.10.0'
+  AUDIT_REF:  'v2.11.0'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/README.md
+++ b/plugins/pp-sync/README.md
@@ -66,7 +66,7 @@ Full schema reference: [`skills/pp-sync/references/cli-reference.md`](skills/pp-
 
 ## Tests
 
-`plugins/pp-sync/tests/` ships regression coverage across seven bash suites covering parser correctness, registration atomicity, URL validation, command flows, subcommand safety, installer behavior, and mocked `pac` CLI flows. Run locally:
+`plugins/pp-sync/tests/` ships regression coverage across eight bash suites covering parser correctness, registration atomicity, URL validation, command flows, subcommand safety, installer behavior, mocked `pac` CLI flows, and journal state/concurrency behavior. Run locally:
 
 ```bash
 bash plugins/pp-sync/tests/test_load_project.sh
@@ -76,6 +76,7 @@ bash plugins/pp-sync/tests/test_command_flows.sh
 bash plugins/pp-sync/tests/test_subcommand_safety.sh
 bash plugins/pp-sync/tests/test_install_script.sh
 bash plugins/pp-sync/tests/test_pac_mocked.sh
+bash plugins/pp-sync/tests/test_journal_state.sh
 ```
 
 See [`tests/README.md`](tests/README.md) for fixture conventions and how to add tests for new subcommands.

--- a/plugins/pp-sync/tests/README.md
+++ b/plugins/pp-sync/tests/README.md
@@ -1,6 +1,6 @@
 # pp-sync test suites
 
-Bash regression tests for `pp` CLI behavior. Seven suites run in CI on every PR via `.github/workflows/plugin-validate.yml`.
+Bash regression tests for `pp` CLI behavior. Eight suites run in CI on every PR via `.github/workflows/plugin-validate.yml`.
 
 ## Suites
 
@@ -13,6 +13,7 @@ Bash regression tests for `pp` CLI behavior. Seven suites run in CI on every PR 
 | `test_subcommand_safety.sh` | 30 | Negative and edge-case coverage for subcommands beyond the parser: page-name traversal/injection rejection (incl. empty-slug rejection), solution-name CLI-arg validation, journal `Issue:` extraction invariants, solution-pick range validation, and doctor pipefail tolerance. |
 | `test_install_script.sh` | 13 | Installer UX and safety: fresh install, idempotent re-run, non-symlink backup behavior, PATH guidance, and installed `pp help` smoke check. |
 | `test_pac_mocked.sh` | 23 | Mocked `pac` CLI flows in CI: doctor, switch/status, download/upload, solution export/import, validate-only upload, diff, and failure-injection paths without requiring a real tenant. |
+| `test_journal_state.sh` | 10 | Journal active-issue state tracking and concurrency: state lifecycle, stale-state clearing, JOURNAL.md fallback, atomic concurrent opens, and project-remove cleanup. |
 
 Run any suite locally:
 

--- a/plugins/pp-sync/tests/test_pac_contract.sh
+++ b/plugins/pp-sync/tests/test_pac_contract.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# Contract tests for the pac CLI surface that pp-sync depends on.
+#
+# Defines, in code, what pp's parsers expect from each `pac` subcommand:
+#   - which strings/patterns must appear in stdout
+#   - which exit codes count as success/failure
+#   - what filesystem effects must occur
+#
+# These contracts are the load-bearing assumptions in `bin/pp`'s
+# integration with pac. The mock at tests/mocks/pac MUST satisfy them
+# for the mocked test suite to be a faithful stand-in.
+#
+# Two run modes:
+#
+#   bash test_pac_contract.sh            # default: against the mock pac
+#   PP_PAC_REAL=1 bash test_pac_contract.sh
+#                                         # against the real pac CLI
+#
+# CI runs the default mode (mock). Maintainers run the PP_PAC_REAL=1
+# mode before each release to catch drift between real pac and the
+# mock — this is the regression that the v2.10.0 changelog acknowledged
+# but didn't have automated coverage for.
+#
+# Contract failures from EITHER mode are real bugs:
+#   - mock fails contract → mock needs updating to match real pac
+#   - real pac fails contract → pp's parsers will break on this pac
+#     version; pp needs adjusting
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOCK_DIR="$SCRIPT_DIR/mocks"
+
+PASS=0
+FAIL=0
+SKIP=0
+FAIL_NAMES=()
+
+TMPDIRS=()
+cleanup_tmpdirs() {
+    local tmp
+    for tmp in "${TMPDIRS[@]:-}"; do
+        [ -n "$tmp" ] && rm -rf "$tmp"
+    done
+}
+trap cleanup_tmpdirs EXIT
+
+assert_pass() {
+    PASS=$((PASS + 1))
+    printf '  OK   %s\n' "$1"
+}
+
+assert_fail() {
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=( "$1" )
+    printf '  FAIL %s\n' "$1" >&2
+    [ -n "${2:-}" ] && printf '       %s\n' "$2" >&2 || true
+}
+
+skip() {
+    SKIP=$((SKIP + 1))
+    printf '  SKIP %s — %s\n' "$1" "$2"
+}
+
+# --- mode setup ---------------------------------------------------------
+
+if [ "${PP_PAC_REAL:-0}" = "1" ]; then
+    if ! command -v pac >/dev/null 2>&1; then
+        echo "SKIP — PP_PAC_REAL=1 but pac CLI is not installed"
+        exit 0
+    fi
+    PAC_BIN="$(command -v pac)"
+    MODE="real-pac"
+    # Real pac requires real auth. Tests that need write/read against
+    # an actual environment are skipped in this mode.
+    REAL_MODE=1
+else
+    PAC_BIN="$MOCK_DIR/pac"
+    MODE="mock-pac"
+    REAL_MODE=0
+fi
+
+[ -x "$PAC_BIN" ] || { echo "Cannot find pac at $PAC_BIN" >&2; exit 1; }
+
+printf 'Contract testing pac CLI against: %s (%s)\n\n' "$PAC_BIN" "$MODE"
+
+# Per-test isolated mock state (only relevant for mock mode)
+new_state_dir() {
+    local d
+    d=$(mktemp -d)
+    TMPDIRS+=( "$d" )
+    printf '%s\n' "$d"
+}
+
+run_pac() {
+    local state="$1"; shift
+    if [ "$REAL_MODE" = "1" ]; then
+        "$PAC_BIN" "$@"
+    else
+        PP_MOCK_PAC_STATE_DIR="$state" "$PAC_BIN" "$@"
+    fi
+}
+
+# --- Section 1: pac auth list contract ----------------------------------
+#
+# pp parses this to verify a profile is registered:
+#   pac auth list 2>/dev/null | grep -qE "UNIVERSAL[[:space:]]+${PROFILE}\\b"
+#
+# Contract:
+#   - returns 0 on success
+#   - lines for registered profiles match: ^[anything]UNIVERSAL[ws]<name>[ws]<url>
+#   - the active profile MAY have a `*` marker — pp doesn't depend on it
+#   - empty profile list is valid (returns 0 with header-only output)
+
+echo "Section 1 — pac auth list contract"
+echo
+
+state=$(new_state_dir)
+if [ "$REAL_MODE" = "0" ]; then
+    # Pre-populate the mock with a known profile
+    echo "myprof=https://acme-dev.crm.dynamics.com/" > "$state/profiles"
+    echo "myprof" > "$state/selected"
+fi
+
+out=$(run_pac "$state" auth list 2>/dev/null || true)
+
+# Contract: each profile row contains "UNIVERSAL" followed by name + URL
+case "$out" in
+    *"UNIVERSAL"*)
+        assert_pass "auth list output contains 'UNIVERSAL' (profile-row marker pp greps for)"
+        ;;
+    *)
+        if [ "$REAL_MODE" = "1" ] && [ -z "$out" ]; then
+            skip "auth list 'UNIVERSAL' marker" "real pac with zero registered profiles"
+        else
+            assert_fail "auth list missing 'UNIVERSAL' marker" "got: $(printf '%s' "$out" | head -3)"
+        fi
+        ;;
+esac
+
+# Contract: pp's actual parsing depends ONLY on the substring
+# `UNIVERSAL[[:space:]]+<profile-name>\b` appearing on a row. Real
+# pac (as of v1.x) inserts several columns between Name and URL
+# (User, Cloud, Type, Environment). The mock has fewer columns. Both
+# satisfy pp's contract because pp doesn't parse URL from auth list
+# at all — that comes from `pac org who`.
+if printf '%s' "$out" | grep -qE 'UNIVERSAL[[:space:]]+\S+'; then
+    assert_pass "auth list rows have 'UNIVERSAL <profile-name>' shape pp greps for"
+else
+    if [ "$REAL_MODE" = "1" ] && [ -z "$out" ]; then
+        skip "auth list row shape" "real pac with zero registered profiles"
+    else
+        assert_fail "auth list row shape changed" "got: $(printf '%s' "$out" | head -5)"
+    fi
+fi
+
+# Optional: an HTTPS URL appears somewhere in the row (pp doesn't
+# parse it but it's a sanity check that profiles HAVE env URLs).
+# This is a soft check — failures don't block the suite.
+if printf '%s' "$out" | grep -qE 'https?://'; then
+    assert_pass "auth list rows include an https:// URL somewhere"
+else
+    if [ "$REAL_MODE" = "1" ] && [ -z "$out" ]; then
+        skip "auth list URL presence" "no profiles registered"
+    else
+        assert_fail "auth list rows missing URL"
+    fi
+fi
+
+# --- Section 2: pac auth select contract -------------------------------
+#
+# pp parses this only via exit code. Output shape doesn't matter.
+# Contract: exits 0 for known profile, non-zero for unknown.
+
+echo
+echo "Section 2 — pac auth select contract"
+echo
+
+if [ "$REAL_MODE" = "0" ]; then
+    state=$(new_state_dir)
+    echo "myprof=https://example.com/" > "$state/profiles"
+
+    if run_pac "$state" auth select --name myprof >/dev/null 2>&1; then
+        assert_pass "auth select on known profile exits 0"
+    else
+        assert_fail "auth select on known profile exited non-zero"
+    fi
+
+    if run_pac "$state" auth select --name nothere >/dev/null 2>&1; then
+        assert_fail "auth select on unknown profile exited 0 (should be non-zero)"
+    else
+        assert_pass "auth select on unknown profile exits non-zero"
+    fi
+else
+    skip "auth select known/unknown profile" "real pac would mutate user state"
+fi
+
+# --- Section 3: pac org who contract -----------------------------------
+#
+# pp parses this via:
+#   actual=$(pac org who 2>&1 | awk -F': ' '/Environment Url/{print $2; exit}')
+#
+# Contract:
+#   - returns 0 when a profile is selected
+#   - stdout includes a line `[anything]Environment Url: <https-url>`
+#   - the URL appears after the FIRST `: ` on that line (awk -F': ' $2)
+#   - returns non-zero when no profile selected (and DOES NOT print
+#     'Environment Url:')
+
+echo
+echo "Section 3 — pac org who contract"
+echo
+
+state=$(new_state_dir)
+if [ "$REAL_MODE" = "0" ]; then
+    echo "myprof=https://acme-dev.crm.dynamics.com/" > "$state/profiles"
+    echo "myprof" > "$state/selected"
+fi
+
+out=$(run_pac "$state" org who 2>&1 || true)
+url=$(printf '%s' "$out" | awk -F': ' '/Environment Url/{print $2; exit}')
+
+case "$url" in
+    https://*)
+        assert_pass "org who: 'Environment Url:' line present and URL parseable"
+        ;;
+    *)
+        if [ "$REAL_MODE" = "1" ]; then
+            skip "org who URL parse" "real pac without a selected profile"
+        else
+            assert_fail "org who URL not parseable via 'Environment Url'" "got: $(printf '%s' "$out" | head -5)"
+        fi
+        ;;
+esac
+
+# --- Section 4: pac paportal upload --validateBeforeUpload contract ----
+#
+# pp invokes this and checks exit code only. Validation success message
+# must NOT contain 'Upload complete' — otherwise pp's "did it actually
+# push" detection breaks.
+
+echo
+echo "Section 4 — pac paportal upload --validate-only contract"
+echo
+
+if [ "$REAL_MODE" = "0" ]; then
+    state=$(new_state_dir)
+    out=$(run_pac "$state" paportal upload --path /tmp/x --validateBeforeUpload 2>&1 || true)
+    case "$out" in
+        *"Validation"*|*"validate"*|*"validating"*|*"Validating"*)
+            assert_pass "paportal upload --validateBeforeUpload mentions validation"
+            ;;
+        *)
+            assert_fail "paportal upload --validateBeforeUpload doesn't mention validation" \
+                "got: $(printf '%s' "$out" | head -3)"
+            ;;
+    esac
+else
+    skip "paportal upload --validate-only" "real pac would touch a real environment"
+fi
+
+# --- Section 5: pac solution unpack contract ---------------------------
+#
+# pp doesn't parse the output; it just needs a folder containing entity
+# subfolders to result.
+# Contract: --folder F must produce F/Entities/ (or F/Other/ — pp checks
+# 'Entities' specifically when reporting count).
+
+echo
+echo "Section 5 — pac solution unpack contract"
+echo
+
+if [ "$REAL_MODE" = "0" ]; then
+    state=$(new_state_dir)
+    work=$(mktemp -d); TMPDIRS+=( "$work" )
+    # Mock unpack expects a zipfile but doesn't really read it
+    : > "$work/dummy.zip"
+    run_pac "$state" solution unpack --zipfile "$work/dummy.zip" --folder "$work/unpacked" >/dev/null 2>&1 || true
+
+    if [ -d "$work/unpacked" ]; then
+        assert_pass "solution unpack creates --folder target dir"
+        # pp's `find $unpack_dir/Entities` count check requires Entities/
+        if [ -d "$work/unpacked/Entities" ]; then
+            assert_pass "solution unpack creates Entities/ subdir (pp counts these)"
+        else
+            assert_fail "solution unpack didn't create Entities/" \
+                "tree: $(find "$work/unpacked" -maxdepth 2 -type d 2>/dev/null)"
+        fi
+    else
+        assert_fail "solution unpack didn't create the target folder"
+    fi
+else
+    skip "solution unpack folder shape" "real pac requires a real solution zip"
+fi
+
+# --- Section 6: pac --version contract ---------------------------------
+#
+# Not used by pp itself, but documents that the binary responds to
+# --version (the `command -v pac` plus a version probe is how doctor
+# checks that pac is installed AND callable).
+
+echo
+echo "Section 6 — pac --version contract"
+echo
+
+if run_pac "$(new_state_dir)" --version >/dev/null 2>&1; then
+    assert_pass "pac --version exits 0 (pac is callable)"
+else
+    if [ "$REAL_MODE" = "1" ]; then
+        # Some pac versions use 'pac help' instead. Accept that fallback.
+        if run_pac "$(new_state_dir)" help >/dev/null 2>&1; then
+            assert_pass "pac help exits 0 (pac is callable, --version unsupported)"
+        else
+            assert_fail "neither pac --version nor pac help exits 0"
+        fi
+    else
+        assert_fail "mock pac --version exits non-zero"
+    fi
+fi
+
+# --- Summary -----------------------------------------------------------
+
+echo
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+    if [ "$SKIP" -gt 0 ]; then
+        printf '%d/%d passed (%d skipped — see notes above)\n' "$PASS" "$TOTAL" "$SKIP"
+    else
+        printf '%d/%d passed\n' "$PASS" "$TOTAL"
+    fi
+    exit 0
+else
+    printf '%d/%d passed; failures: %s\n' "$PASS" "$TOTAL" "${FAIL_NAMES[*]}" >&2
+    exit 1
+fi

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.10.0"
+        "version": "2.11.0"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.3.0",
+        "pp-sync": "2.4.0",
         "pp-permissions-audit": "1.5.5"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.10.0"
+        "pp_permissions_audit_ci_ref": "v2.11.0"
     }
 }


### PR DESCRIPTION
Closes the \"real-pac behavior diff the mock can't catch\" gap from v2.10.0.

## Added: \`tests/test_pac_contract.sh\` (10 contract assertions)

Defines what \`pp\` depends on from each \`pac\` subcommand: output patterns, exit codes, filesystem effects.

Two run modes:
- **mock mode** (default, CI) — verifies \`tests/mocks/pac\` satisfies the contract
- **real-pac mode** (\`PP_PAC_REAL=1\`) — verifies the actual installed \`pac\` still satisfies the contract; for release-prep

CI runs mock mode on every PR. Maintainers run real-pac mode before each release.

## Bug surfaced + fixed (same release)

Running against real pac immediately caught that real pac's \`auth list\` has 9 columns (Index/Active/Kind/Name/User/Cloud/Type/Environment/URL) while the mock has 5. My initial contract asserted \"UNIVERSAL <name> <url>\" — would have rejected real pac. But pp's actual \`grep -qE \"UNIVERSAL[[:space:]]+\${PROFILE}\\b\"\` doesn't depend on column 5 being a URL. **Relaxed the contract to match pp's actual parser** (substring \"UNIVERSAL <name>\"), with a soft URL-presence sanity check.

The contract reflects the dependency, not the format.

## Test count: 238 (was 228)

| | Before | After |
|---|---|---|
| Marketplace | 2.10.0 | **2.11.0** |
| pp-sync | 2.3.0 | **2.4.0** |