### PR TITLE
v2.11.1: pp setup full-flow stdin works (was silently broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this marketplace are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with version numbers tracking the marketplace as a whole. Per-plugin versions live in each `plugins/<name>/.claude-plugin/plugin.json` and are noted below where they advance.
 
+## [2.11.1] — 2026-04-30
+
+Closes the v2.10.0 "covered indirectly via `pp project add`" gap with an actual full-flow setup test. Surfaced and fixed a real bug that had made scripted `pp setup` invocation impossible since the function was first written.
+
+### Fixed (pp-sync v2.4.1)
+
+- **`cmd_setup` now correctly separates the candidate-list iteration from the user-prompt stdin.** The previous `while IFS= read -r candidate; ... done <<< "$candidates"` redirected stdin to the heredoc for the entire loop body — every inner `read -r -p "Project name [...]: " name` call read from the candidates list, not from the user's terminal/piped stdin. With one candidate in the list, the first inner read consumed the candidate path as the project name; with subsequent reads, the heredoc was exhausted and `read` returned EOF, triggering a silent `set -e` abort.
+  - **Symptom**: `printf '...inputs...' | pp setup` silently exited at the first per-candidate prompt with code 1, no projects registered. Anyone trying to script setup (CI bootstrap, dev-onboarding, etc.) hit this.
+  - **Manual interactive use was unaffected** — when stdin is a TTY, the inner reads see the TTY directly because the `<<<` redirect doesn't shadow it. That's why this bug had been latent since the function was written.
+  - **Fix**: read candidates from fd 3 (`while IFS= read -r -u 3 candidate; do ... done 3<<< "$candidates"`). Stdin (fd 0) flows through to the inner prompt reads as expected.
+
+### Tests added (test count: 246, was 238)
+
+- 8 new full-flow setup assertions in `test_command_flows.sh` Section 10b — drive the entire 8-prompt registration via piped stdin, verify the resulting conf has correct NAME / PROFILE / ENV_URL (pulled from `pac org who` via the mock) / SITE_DIR, and that the suggested alias was written. The previous 5 assertions still verify the detection-only / decline path. **The "covered indirectly via `pp project add`" caveat in v2.10.0's gap list is now resolved** — full setup is exercised directly.
+
+### Why this matters
+
+Two days of probing surfaced a bug that was invisible to interactive users for the function's entire history. The bug was only reachable via piped stdin — and pp-sync had never had a test that piped stdin to setup. The lesson is the same one the v2.7.x rounds taught: **untested code paths harbor bugs even when they look innocuous, and the bugs are often only reachable from contexts the original author didn't anticipate.**
+
 ## [2.11.0] — 2026-04-30
 
 Closes the "real-pac behavior diff the mock can't catch" gap from v2.10.0's "remaining gaps" list. New contract test suite — runnable against either the mock (default, CI) or real `pac` (release-prep) — defines what pp depends on from each pac subcommand and verifies the dependency holds.
@@ -648,6 +667,7 @@ Static analysis of Power Pages portal permissions and Web API configuration. Std
 - Per-plugin manifests + READMEs
 - `pp` installer (`./plugins/pp-sync/install.sh`) symlinks the CLI into `~/.local/bin/`
 
+[2.11.1]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.11.1
 [2.11.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.11.0
 [2.10.0]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.10.0
 [2.9.4]: https://github.com/Nerdy-Q/claude-power-pages-plugins/releases/tag/v2.9.4

--- a/plugins/pp-permissions-audit/CI.md
+++ b/plugins/pp-permissions-audit/CI.md
@@ -16,14 +16,14 @@ What it does:
 
 - Triggers on PRs that touch portal source files (web-pages, web-templates, site-settings, table-permissions, etc.)
 - Auto-detects the site folder (the first `<name>---<name>/` containing `website.yml` + `web-pages/`)
-- Fetches the audit script from a pinned tag (`v2.11.0` by default)
+- Fetches the audit script from a pinned tag (`v2.11.1` by default)
 - Runs `audit.py --severity ERROR --exit-code` to gate the PR
 - Uploads the **full report** (including WARN + INFO findings) as a build artifact, so reviewers can read all findings without re-running locally
 - Optional: commenting the summary on the PR (commented out by default — uncomment to enable, plus the `permissions:` block)
 
 ### Pinning to a version
 
-The template uses `AUDIT_REF: 'v2.11.0'` to pin to a released version. Bump this when you upgrade. Alternatives:
+The template uses `AUDIT_REF: 'v2.11.1'` to pin to a released version. Bump this when you upgrade. Alternatives:
 
 - `AUDIT_REF: 'main'` — always latest (convenient for early adopters; brittle for production)
 - `AUDIT_REF: '<commit-sha>'` — exact commit pin (most reproducible)
@@ -94,7 +94,7 @@ steps:
       versionSpec: '3.11'
 
   - bash: |
-      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.11.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+      curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.11.1/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
            -o /tmp/audit.py
     displayName: 'Fetch audit script'
 
@@ -157,7 +157,7 @@ If your CI is generic shell (Jenkins, CircleCI, GitLab, Buildkite):
 set -euo pipefail
 
 # 1. Fetch the audit script
-curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.11.0/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
+curl -fsSL https://raw.githubusercontent.com/Nerdy-Q/claude-power-pages-plugins/v2.11.1/plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py \
      -o /tmp/audit.py
 
 # 2. Detect site folder

--- a/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
+++ b/plugins/pp-permissions-audit/examples/github-actions/power-pages-audit.yml
@@ -8,7 +8,7 @@
 # findings, and uploads the full report (incl. WARN / INFO) as a build artifact.
 #
 # Pin the audit script to a release tag for stability:
-#   AUDIT_REF:  'v2.11.0'   (recommended for production projects)
+#   AUDIT_REF:  'v2.11.1'   (recommended for production projects)
 #   AUDIT_REF: 'main'     (always latest — convenient for early adopters)
 #
 # Customize the SITE_DIR_PATTERN if your site folder doesn't match the canonical
@@ -42,7 +42,7 @@ on:
 env:
   # Pin to a released version of the audit script. Update when you upgrade.
   AUDIT_REPO: 'Nerdy-Q/claude-power-pages-plugins'
-  AUDIT_REF:  'v2.11.0'
+  AUDIT_REF:  'v2.11.1'
   AUDIT_PATH: 'plugins/pp-permissions-audit/skills/pp-permissions-audit/scripts/audit.py'
 
 jobs:

--- a/plugins/pp-sync/.claude-plugin/plugin.json
+++ b/plugins/pp-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "pp-sync",
     "description": "Run Power Pages classic portal sync workflows safely — pac paportal download/upload, pac solution export/unpack, project-aware wrapper-script delegation, and bulk-upload safety guards. Use when the user wants to sync a Power Pages portal, run pp down/up/doctor, sync-down-dev, project-prefixed wrapper scripts, deploy portal changes, pull schema, or recover from a hung portal cache. NOT for code sites (React/Vue/Astro SPAs).",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "author": {
         "name": "NerdyQ",
         "url": "https://github.com/Nerdy-Q"

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -523,8 +523,12 @@ cmd_setup() {
         local branch
         read -r -p "Default branch (blank for any): " branch
 
-        # Journaling and Project Boards
-        local board_url board_system ai_attr auto_journal
+        # Journaling and Project Boards. Default the three optional
+        # fields to empty/safe values up-front so they're set even on
+        # the journaling-declined branch — under `set -u` (active in
+        # main) referencing an unset local in the heredoc below would
+        # abort.
+        local board_url="" board_system="" ai_attr="" auto_journal
         echo
         info "--- Journaling & Project Boards ---"
         read -r -p "Enable automated journaling for this project? [Y/n]: " auto_journal

--- a/plugins/pp-sync/bin/pp
+++ b/plugins/pp-sync/bin/pp
@@ -444,7 +444,15 @@ cmd_setup() {
     echo
     confirm_action "Walk through registering each candidate?"
 
-    while IFS= read -r candidate; do
+    # Read candidates from fd 3 (not stdin) so the inner `read -r -p`
+    # prompts inside the loop body still consume the user's terminal
+    # input. With `done <<< "$candidates"`, the heredoc would shadow
+    # stdin for the entire loop — every prompt's `read` would EOF on
+    # the candidates heredoc and silently abort under `set -e`.
+    # This is why driving `pp setup` via piped stdin was previously
+    # impossible; the prompt reads consumed candidates instead of
+    # answers.
+    while IFS= read -r -u 3 candidate; do
         [ -z "$candidate" ] && continue
         echo
         echo "${BOLD}Candidate:${RST} $candidate"
@@ -567,7 +575,7 @@ EOF
             fi
         fi
 
-    done <<< "$candidates"
+    done 3<<< "$candidates"
 
     echo
     ok "Setup complete."

--- a/plugins/pp-sync/tests/test_command_flows.sh
+++ b/plugins/pp-sync/tests/test_command_flows.sh
@@ -407,19 +407,11 @@ assert_contains "invalid explicit sync-pages direction rejected" "Invalid sync-p
 # --- Section 10: cmd_help ------------------------------------------------
 
 echo
-echo "Section 10b — cmd_setup detection phase"
+echo "Section 10b — cmd_setup detection + full registration flow"
 echo
 
 # Test the discovery / detection phases of `pp setup` — PAC profile
 # enumeration, candidate-folder scanning, and the confirmation prompt.
-# We DO NOT drive the full 8-prompt registration flow because that
-# requires non-trivial stdin orchestration; instead we verify setup
-# correctly reaches the candidate-walkthrough phase, then cleanly
-# aborts when the user declines.
-#
-# Full registration is exercised by test_register_atomic.sh via
-# `pp project add`, which uses the same identifier-validation and
-# atomic-write paths as setup.
 
 setup_tmp=$(mktemp -d); TMPDIRS+=( "$setup_tmp" )
 fake_home="$setup_tmp/home"
@@ -442,16 +434,59 @@ setup_out=$(printf 'n\n' | \
 assert_contains "setup detects PAC profile from mock" "myprof" "$setup_out"
 assert_contains "setup scans for Power Pages site folders" "Scanning" "$setup_out"
 assert_contains "setup discovers the candidate folder" "acme---acme" "$setup_out"
-# The "Walk through ..." prompt appears via read -p which writes to
-# stderr SYNCHRONOUSLY with the read syscall; in piped contexts the
-# prompt may be intermingled or pre-consumed. Instead assert on the
-# user-decline branch's output ("Aborted").
 assert_contains "setup respects user declining walkthrough" "Aborted" "$setup_out"
 
-# When user declines, NO projects should be registered
 project_count=$(find "$setup_tmp/pp/projects" -maxdepth 1 -name '*.conf' 2>/dev/null | wc -l | tr -d ' ')
 [ "${project_count:-0}" = "0" ] && assert_pass "setup respects 'n' to walkthrough (no confs created)" \
     || assert_fail "setup created a conf despite user declining" "found $project_count conf(s)"
+
+# Full registration via piped stdin. The fd-3 separation in cmd_setup
+# (v2.11.1+) lets inner read prompts consume stdin instead of the
+# candidates heredoc.
+#
+# Stdin sequence (8 prompts):
+#   y      → walk through candidates
+#   ""     → accept default project name (acmecorp)
+#   ""     → accept suggested alias
+#   myprof → PAC profile
+#   ""     → blank website ID
+#   ""     → no solutions
+#   ""     → no default branch
+#   n      → disable journaling (skips remaining 3 prompts)
+
+setup_tmp2=$(mktemp -d); TMPDIRS+=( "$setup_tmp2" )
+mkdir -p "$setup_tmp2/home/Projects/AcmeCorp/acme---acme/web-pages"
+echo "adx_name: Acme Site" > "$setup_tmp2/home/Projects/AcmeCorp/acme---acme/website.yml"
+mock_state2="$setup_tmp2/pac"
+mkdir -p "$mock_state2"
+echo "myprof=https://acme-dev.crm.dynamics.com/" > "$mock_state2/profiles"
+echo "myprof" > "$mock_state2/selected"
+
+setup_out2=$(printf 'y\n\n\nmyprof\n\n\n\nn\n' | \
+    HOME="$setup_tmp2/home" PATH="$mock_dir:$PATH" \
+    PP_CONFIG_DIR="$setup_tmp2/pp" \
+    PP_MOCK_PAC_STATE_DIR="$mock_state2" \
+    "$PP_BIN" setup 2>&1 || true)
+
+assert_contains "full-flow setup ran to completion" "Setup complete" "$setup_out2"
+assert_contains "full-flow setup registered acmecorp" "Registered acmecorp" "$setup_out2"
+
+conf_path="$setup_tmp2/pp/projects/acmecorp.conf"
+[ -f "$conf_path" ] && assert_pass "full-flow setup wrote conf at projects/acmecorp.conf" \
+    || assert_fail "full-flow setup didn't write conf" "out: $(printf '%s' "$setup_out2" | tail -20)"
+
+if [ -f "$conf_path" ]; then
+    conf_content=$(cat "$conf_path")
+    assert_contains "setup-conf has correct NAME" 'NAME="acmecorp"' "$conf_content"
+    assert_contains "setup-conf has correct PROFILE" 'PROFILE="myprof"' "$conf_content"
+    assert_contains "setup-conf pulled ENV_URL from pac org who" "acme-dev.crm.dynamics.com" "$conf_content"
+    assert_contains "setup-conf has SITE_DIR relative to repo" 'SITE_DIR="acme---acme"' "$conf_content"
+fi
+
+# Alias was suggested + accepted (default 5-char prefix of "acmecorp")
+[ -f "$setup_tmp2/pp/aliases" ] && grep -q "=acmecorp" "$setup_tmp2/pp/aliases" \
+    && assert_pass "full-flow setup wrote suggested alias" \
+    || assert_fail "no alias written" "aliases: $(cat "$setup_tmp2/pp/aliases" 2>/dev/null)"
 
 echo
 echo "Section 10 — cmd_help"

--- a/versions.json
+++ b/versions.json
@@ -1,14 +1,14 @@
 {
     "marketplace": {
         "name": "nq-claude-power-pages-plugins",
-        "version": "2.11.0"
+        "version": "2.11.1"
     },
     "plugins": {
         "pp-portal": "2.2.2",
-        "pp-sync": "2.4.0",
+        "pp-sync": "2.4.1",
         "pp-permissions-audit": "1.5.5"
     },
     "docs": {
-        "pp_permissions_audit_ci_ref": "v2.11.0"
+        "pp_permissions_audit_ci_ref": "v2.11.1"
     }
 }


### PR DESCRIPTION
Closes the v2.10.0 \"covered indirectly via \`pp project add\`\" gap. **Surfaced and fixed a real bug** that made scripted \`pp setup\` impossible since the function was first written.

## The bug

\`cmd_setup\`'s candidate-walking loop used \`done <<< \"\$candidates\"\` which redirected stdin to the candidates heredoc for the entire loop body. Every inner \`read -r -p \"Project name [...]: \" name\` read from candidates, not from stdin.

- With one candidate: the first inner read consumed the candidate path as the project name
- After candidates exhausted: subsequent reads got EOF → silent \`set -e\` abort

**Symptom**: \`printf '...' | pp setup\` silently exited code 1 with no projects registered. Anyone trying to script setup (CI bootstrap, dev onboarding) hit this. **Interactive TTY use was unaffected** — `<<<` doesn't shadow a TTY stdin the same way it does a piped one. That's why this bug had been latent the function's entire history.

## The fix

Read candidates from fd 3:

```bash
while IFS= read -r -u 3 candidate; do
    ...
    read -r -p \"Project name: \" name   # reads from stdin (fd 0)
    ...
done 3<<< \"\$candidates\"
```

Stdin (fd 0) flows through to inner prompts. Functionally unchanged for interactive users; works for scripted users for the first time.

## Tests added (8 assertions, count now 246)

\`test_command_flows.sh\` Section 10b grew from 5 to 13 assertions. The new 8 drive the entire 8-prompt registration via piped stdin:

| Assertion | Verifies |
|---|---|
| 'Setup complete' in output | Full flow ran to completion |
| 'Registered acmecorp' in output | Registration succeeded |
| Conf file at projects/acmecorp.conf | Atomic write happened |
| NAME='acmecorp' | Correct name from default-derivation |
| PROFILE='myprof' | Profile prompt input was consumed |
| ENV_URL=acme-dev.crm.dynamics.com | Pulled from \`pac org who\` (mock) |
| SITE_DIR='acme---acme' | Computed correctly relative to repo |
| Suggested alias written | Alias file got the new entry |

## Versions

| | Before | After |
|---|---|---|
| Marketplace | 2.11.0 | **2.11.1** |
| pp-sync | 2.4.0 | **2.4.1** |